### PR TITLE
Use GCC 9.3 on Summit

### DIFF
--- a/configs/summit/compilers.yaml
+++ b/configs/summit/compilers.yaml
@@ -1,38 +1,38 @@
 compilers:
-- compiler:
-    paths:
-      cc: /sw/summit/gcc/10.2.0/bin/gcc
-      cxx: /sw/summit/gcc/10.2.0/bin/g++
-      f77: /sw/summit/gcc/10.2.0/bin/gfortran
-      fc: /sw/summit/gcc/10.2.0/bin/gfortran
-    operating_system: rhel8
-    target: ppc64le
-    modules:
-      - gcc/10.2.0
-    environment: {}
-    extra_rpaths:
-      - /sw/summit/gcc/10.2.0/lib
-      - /sw/summit/gcc/10.2.0/lib64
-      - /sw/summit/gcc/10.2.0/libexec
-    flags: {}
-    spec: gcc@10.2.0
 #- compiler:
 #    paths:
-#      cc: /sw/summit/gcc/9.3.0-1/bin/gcc
-#      cxx: /sw/summit/gcc/9.3.0-1/bin/g++
-#      f77: /sw/summit/gcc/9.3.0-1/bin/gfortran
-#      fc: /sw/summit/gcc/9.3.0-1/bin/gfortran
+#      cc: /sw/summit/gcc/10.2.0/bin/gcc
+#      cxx: /sw/summit/gcc/10.2.0/bin/g++
+#      f77: /sw/summit/gcc/10.2.0/bin/gfortran
+#      fc: /sw/summit/gcc/10.2.0/bin/gfortran
 #    operating_system: rhel8
 #    target: ppc64le
 #    modules:
-#      - gcc/9.3.0
+#      - gcc/10.2.0
 #    environment: {}
 #    extra_rpaths:
-#      - /sw/summit/gcc/9.3.0-1/lib
-#      - /sw/summit/gcc/9.3.0-1/lib64
-#      - /sw/summit/gcc/9.3.0-1/libexec
+#      - /sw/summit/gcc/10.2.0/lib
+#      - /sw/summit/gcc/10.2.0/lib64
+#      - /sw/summit/gcc/10.2.0/libexec
 #    flags: {}
-#    spec: gcc@9.3.0
+#    spec: gcc@10.2.0
+- compiler:
+    paths:
+      cc: /sw/summit/gcc/9.3.0-1/bin/gcc
+      cxx: /sw/summit/gcc/9.3.0-1/bin/g++
+      f77: /sw/summit/gcc/9.3.0-1/bin/gfortran
+      fc: /sw/summit/gcc/9.3.0-1/bin/gfortran
+    operating_system: rhel8
+    target: ppc64le
+    modules:
+      - gcc/9.3.0
+    environment: {}
+    extra_rpaths:
+      - /sw/summit/gcc/9.3.0-1/lib
+      - /sw/summit/gcc/9.3.0-1/lib64
+      - /sw/summit/gcc/9.3.0-1/libexec
+    flags: {}
+    spec: gcc@9.3.0
 #- compiler:
 #    environment: {}
 #    extra_rpaths:

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -19,16 +19,16 @@ packages:
     version: [11.3.1]
     buildable: false
     externals:
-      #- spec: "cuda@11.4.0%gcc@10.2.0"
+      #- spec: "cuda@11.4.0%gcc@9.3.0"
       #  modules:
       #    - cuda/11.4.0
-      - spec: "cuda@11.3.1%gcc@10.2.0"
+      - spec: "cuda@11.3.1%gcc@9.3.0"
         modules:
           - cuda/11.3.1
-      #- spec: "cuda@11.0.3%gcc@10.2.0"
+      #- spec: "cuda@11.0.3%gcc@9.3.0"
       #  modules:
       #    - cuda/11.0.3
-      #- spec: "cuda@10.2.89%gcc@10.2.0"
+      #- spec: "cuda@10.2.89%gcc@9.3.0"
       #  modules:
       #    - cuda/10.2.89
   all:

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -3,14 +3,14 @@ packages:
     version: [10.4]
     buildable: false
     externals:
-      - spec: "spectrum-mpi@10.4%gcc@10.2.0"
-        modules:
-          - gcc/10.2.0
-          - spectrum-mpi/10.4.0.3-20210112
-      #- spec: "spectrum-mpi@10.4%gcc@9.3.0"
+      #- spec: "spectrum-mpi@10.4%gcc@10.2.0"
       #  modules:
-      #    - gcc/9.3.0
+      #    - gcc/10.2.0
       #    - spectrum-mpi/10.4.0.3-20210112
+      - spec: "spectrum-mpi@10.4%gcc@9.3.0"
+        modules:
+          - gcc/9.3.0
+          - spectrum-mpi/10.4.0.3-20210112
       #- spec: "spectrum-mpi@10.4%gcc@7.5.0"
       #  modules:
       #    - gcc/7.5.0
@@ -33,7 +33,7 @@ packages:
       #    - cuda/10.2.89
   all:
     compiler:
-      - gcc@10.2.0
+      - gcc@9.3.0
     providers:
       mpi:
         - spectrum-mpi@10.4


### PR DESCRIPTION
Compatibliity with CUDA 11.X appears to be best served with GCC 9.X, so here we change from GCC 10.2.0 to GCC 9.3.0 on Summit.