### PR TITLE
Make includes insenstive to missing machine files

### DIFF
--- a/tests/test_create_machine_spack_environment.py
+++ b/tests/test_create_machine_spack_environment.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env spack-python
 from tempfile import TemporaryDirectory
 import filecmp
 import os
@@ -11,10 +12,46 @@ def test_basicDirectoryProperties():
         assert filecmp.dircmp(tmpdir, args.directory)
         assert 'darwin' == args.machine
         cmse.CreateEnvDir(args)
-        assert os.path.isfile(os.path.join(tmpdir, 'machine_config.yaml'))
+        assert os.path.isfile(os.path.join(tmpdir, 'general_packages.yaml'))
 
 
 def test_failsWithAnUnregisteredMachine():
     with TemporaryDirectory() as tmpdir:
         args = cmse.Parse(['-d', tmpdir, '-m', 'theGOAT_HPC'])
         pytest.raises(Exception, cmse.CreateEnvDir, args)
+
+
+TESTMACHINE = 'test_machine'
+
+
+def test_missingSourceFilesDontBreakEnv(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        # setup a mirror configuration of spack-manager
+        link_dir = os.path.join(os.environ['SPACK_MANAGER'], 'configs', 'base')
+
+        os.mkdir(os.path.join(tmpdir, 'configs'))
+        os.symlink(link_dir,
+                   os.path.join(tmpdir, 'configs', 'base'))
+        os.mkdir(os.path.join(tmpdir, 'configs', TESTMACHINE))
+
+        # monkeypatches
+        envVars = {'SPACK_MANAGER': tmpdir}
+        monkeypatch.setattr(os, 'environ', envVars)
+
+        def MockFindMachine():
+            return TESTMACHINE
+
+        monkeypatch.setattr(cmse, 'find_machine', MockFindMachine)
+
+        # create spack.yaml
+        args = cmse.Parse(['-d', tmpdir])
+        cmse.CreateEnvDir(args)
+
+        # ideally I'd just try to activate the spack env, but I haven't
+        # figures out good way yet.  Adding spack to PYTHONPATH introduces
+        # a bunch of non-standard module dependencies
+        with open(os.path.join(tmpdir, 'spack.yaml'), 'r') as spackYaml:
+            # verify that no machine yamls are in file
+            for line in spackYaml:
+                assert ('machine' not in line)
+                assert ('-' in line) if 'general' in line else True


### PR DESCRIPTION
This makes it so the `spack.yaml` only populates `includes` based on the files present in the directory.  This will require some caution with `env-templates` since those could get out of match.  I think we will need to add more concretization tests at some point. 

However, to ensure this works I removed the blank `packages.yaml` in the Rhodes config that was added in #33 which triggered failures in the concretization CI test with that PR.