### PR TITLE
Fix for compile_commands failure

### DIFF
--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -73,7 +73,7 @@ class Exawind(CMakePackage, CudaPackage):
 
     @run_after('cmake')
     def copy_compile_commands(self):
-        if self.spec.satisfies('dev_path=*'):
+        source = os.path.join(self.build_directory, "compile_commands.json")
+        if self.spec.satisfies('dev_path=*') and os.path.isfile(source):
             target = os.path.join(self.stage.source_path, "compile_commands.json")
-            source = os.path.join(self.build_directory, "compile_commands.json")
             copyfile(source, target)


### PR DESCRIPTION
This will stop build failures for dev builds of `exawind`.  Still need to figure out why the `compile_commands.json` isn't being created though.