### PR TITLE
Allow unregistered machines to still create environments

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -8,7 +8,6 @@ import os
 import shutil
 
 import manager_cmds.find_machine as fm
-
 from manager_cmds.find_machine import find_machine
 from manager_cmds.includes_creator import IncludesCreator
 
@@ -48,7 +47,8 @@ def create_env(parser, args):
     if os.path.exists(hostPath):
         inc_creator.add_scope('machine', hostPath)
     else:
-        print('Warning: pre-configured machine not setup in spack-manager: %s' % machine)
+        print('Warning: pre-configured'
+              ' machine not setup in spack-manager: %s' % machine)
 
     if args.directory is not None:
         if os.path.exists(args.directory) is False:

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -7,6 +7,8 @@ on a given machine
 import os
 import shutil
 
+import manager_cmds.find_machine as fm
+
 from manager_cmds.find_machine import find_machine
 from manager_cmds.includes_creator import IncludesCreator
 
@@ -27,6 +29,8 @@ def create_env(parser, args):
     """
     if args.machine is not None:
         machine = args.machine
+        if machine not in fm.machine_list.keys():
+            raise Exception('Specified machine %s not defined' % machine)
     else:
         machine = find_machine()
 
@@ -40,32 +44,33 @@ def create_env(parser, args):
     genPath = os.path.join(os.environ['SPACK_MANAGER'], 'configs', 'base')
     inc_creator.add_scope('base', genPath)
     hostPath = os.path.join(os.environ['SPACK_MANAGER'], 'configs', machine)
-    inc_creator.add_scope('machine', hostPath)
 
     if os.path.exists(hostPath):
-        if args.directory is not None:
-            if os.path.exists(args.directory) is False:
-                print("making", args.directory)
-                os.makedirs(args.directory)
-
-            theDir = args.directory
-        else:
-            theDir = os.getcwd()
-
-        include_file_name = 'include.yaml'
-        include_file = os.path.join(theDir, include_file_name)
-        inc_creator.write_includes(include_file)
-
-        include_str = '  - {v}\n'.format(v=include_file_name)
-
-        if args.yaml is not None:
-            assert(os.path.isfile(args.yaml))
-            shutil.copy(args.yaml, os.path.join(theDir, 'spack.yaml'))
-        else:
-            open(os.path.join(theDir, 'spack.yaml'), 'w').write(
-                default_env_file.format(spec=spec, includes=include_str))
+        inc_creator.add_scope('machine', hostPath)
     else:
-        raise Exception('Host not setup in spack-manager: %s' % hostPath)
+        print('Warning: pre-configured machine not setup in spack-manager: %s' % machine)
+
+    if args.directory is not None:
+        if os.path.exists(args.directory) is False:
+            print("making", args.directory)
+            os.makedirs(args.directory)
+
+        theDir = args.directory
+    else:
+        theDir = os.getcwd()
+
+    include_file_name = 'include.yaml'
+    include_file = os.path.join(theDir, include_file_name)
+    inc_creator.write_includes(include_file)
+
+    include_str = '  - {v}\n'.format(v=include_file_name)
+
+    if args.yaml is not None:
+        assert(os.path.isfile(args.yaml))
+        shutil.copy(args.yaml, os.path.join(theDir, 'spack.yaml'))
+    else:
+        open(os.path.join(theDir, 'spack.yaml'), 'w').write(
+            default_env_file.format(spec=spec, includes=include_str))
 
 
 def add_command(parser, command_dict):


### PR DESCRIPTION
@eugeneswalker this should allow you to use `spack manager create-env` on any machine.  We will just need to run `spack compilers find` and/or install compilers before concretizing.