### PR TITLE
Create a way to auto activate an environment upon creation

### DIFF
--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -8,7 +8,8 @@ function quick-activate(){
   spack env activate -d $1
 }
 # function to wrap spack manager calls for shell modification
-function sspack(){
+# i.e. shell-wrapped-spack
+function swspack(){
   spack_command="spack $@"
   if [[ "$*" == *create-env* && "$*" == *-a* ]]; then
     eval $( ${spack_command} )

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -10,9 +10,7 @@ function quick-activate(){
 # function to wrap spack manager calls for shell modification
 function sspack(){
   spack_command="spack $@"
-  echo ${spack_command}
   if [[ "$*" == *create-env* && "$*" == *-a* ]]; then
-    echo "CONDITION MET"
     eval $( ${spack_command} )
   else
     eval ${spack_command}

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -7,3 +7,14 @@ function quick-activate(){
   spack-start
   spack env activate -d $1
 }
+# function to wrap spack manager calls for shell modification
+function sspack(){
+  spack_command="spack $@"
+  echo ${spack_command}
+  if [[ "$*" == *create-env* && "$*" == *-a* ]]; then
+    echo "CONDITION MET"
+    eval $( ${spack_command} )
+  else
+    eval ${spack_command}
+  fi
+}

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -7,14 +7,16 @@ on a given machine
 import os
 import shutil
 
+import argparse
+
 import manager_cmds.find_machine as fm
 from manager_cmds.find_machine import find_machine
 from manager_cmds.includes_creator import IncludesCreator
 
 import spack.main
 import spack.environment as env
+import spack.cmd.env as envcmd
 
-envcmd = spack.main.SpackCommand('env')
 
 default_env_file = (
     """
@@ -78,8 +80,10 @@ def create_env(parser, args):
 
     if args.activate:
         print('activating env {0}'.format(theDir))
-        env.activate(env.Environment(theDir))
-        #envcmd('activate', '-d', theDir, '-p')
+        dumb_parser = argparse.ArgumentParser('dummy')
+        envcmd.env_activate_setup_parser(dumb_parser)
+        activate_args = dumb_parser.parse_args(['-d', theDir, '-p', '--shell', 'bash'])
+        envcmd.env_activate(activate_args)
 
 
 def add_command(parser, command_dict):

--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -35,7 +35,7 @@ machine_list = {
 }
 
 
-def find_machine(parser=None, args=None):
+def find_machine(parser=None, args=None, verbose=True):
     for machine, i_am_this_machine in machine_list.items():
         """
         Since we don't expect uniform environments on all machines
@@ -43,7 +43,8 @@ def find_machine(parser=None, args=None):
         """
         try:
             if i_am_this_machine():
-                print(machine)
+                if verbose:
+                    print(machine)
                 return machine
         except(KeyError):
             """
@@ -58,7 +59,8 @@ def find_machine(parser=None, args=None):
             in the future
             """
             raise
-    print('NOT-FOUND')
+    if verbose:
+        print('NOT-FOUND')
     return 'NOT-FOUND'
 
 

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -8,6 +8,7 @@ import spack.environment as env
 import spack.main
 
 manager = spack.main.SpackCommand('manager')
+envcmd = spack.main.SpackCommand('env')
 
 
 def test_basicDirectoryProperties():
@@ -49,3 +50,24 @@ def test_missingReferenceYamlFilesDontBreakEnv(monkeypatch):
         # ensure that this environment can be created
         # missing includes will cause a failure
         env.Environment(tmpdir)
+
+
+def test_envIsActivatedWithActivateFlag(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        # setup a mirror configuration of spack-manager
+        link_dir = os.path.join(os.environ['SPACK_MANAGER'], 'configs', 'base')
+
+        os.mkdir(os.path.join(tmpdir, 'configs'))
+        os.symlink(link_dir,
+                   os.path.join(tmpdir, 'configs', 'base'))
+
+        # monkeypatches
+        envVars = {'SPACK_MANAGER': tmpdir}
+        monkeypatch.setattr(os, 'environ', envVars)
+
+        manager('create-env', '-d', tmpdir, '-a')
+
+        assert env.active_environment() is not None
+        assert env.active_environment().path == tmpdir
+        # this is required for clean up. need to start using spack test decorators
+        env.deactivate()

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -39,7 +39,9 @@ def test_missingReferenceYamlFilesDontBreakEnv(monkeypatch):
         envVars = {'SPACK_MANAGER': tmpdir}
         monkeypatch.setattr(os, 'environ', envVars)
 
-        def MockFindMachine():
+        def MockFindMachine(verbose=True):
+            if verbose:
+                print(TESTMACHINE)
             return TESTMACHINE
 
         monkeypatch.setattr(create_env, 'find_machine', MockFindMachine)


### PR DESCRIPTION
This took a little hackety hacking. Thanks to @haampie.  I've added the `-a` flag to `spack manager create-env` to activate the environment when you create it.  Unfortunately we can't just call `spack env activate` because spack uses a shell wrapper to call that.  So I wrote a generic shell wrapper that will call the spack command as a subprocess and then call `eval` on what ever gets echoed out.  This wrapper is `swspack` for _shell wrapped spack_.

What this looks like:
```console
# swspack manager create-env -d $SPACK_MANAGER/environments/temp -a
[temp] s1057824:spack-manager psakiev$ 
```

This right now is tuned specifically for this create and activate command but it can be specialized further later. For example we can change directories or use this for running nightly tests.
