### PR TITLE
Remove sierra-python dependencies

### DIFF
--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -22,12 +22,3 @@ packages:
     buildable: false
   cuda:
     version: [11.2.1]
-  python:
-    version: [3.6.10]
-    buildable: false
-    externals:
-    - spec: python@2.7.10
-      prefix: /projects/sierra/linux_rh7/install/Python/2.7/
-    - spec: python@3.6.10
-      modules:
-      - sierra-python/3.6.10

--- a/configs/cee/packages.yaml
+++ b/configs/cee/packages.yaml
@@ -20,15 +20,6 @@ packages:
   hdf5:
     version: [1.10.6]
     variants: +mpi+cxx+hl
-  python:
-    version: [3.6.10]
-    buildable: false
-    externals:
-    - spec: python@2.7.10
-      prefix: /projects/sierra/linux_rh7/install/Python/2.7/
-    - spec: python@3.6.10
-      modules:
-      - sierra-python/3.6.10
   zlib:
     version: [1.2.5]
     buildable: false


### PR DESCRIPTION
Sierra deleted the python3 module which breaks any build that depends on python for these machines.  Let's just build it ourselves from now on. With `spack concretize --reuse` we should really only have to build python once if we need it.

I think the only thing in our stack that relied on it (right now) is using ninja to build packages.