### PR TITLE
Snapshot creation

### DIFF
--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -45,6 +45,9 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('amr-wind+netcdf+mpi')
     depends_on('tioga+shared~nodegid')
     depends_on('yaml-cpp@0.6:')
+    # not required but added so trilinos gets pickes up as a
+    # direct dependency when creating snapshots
+    depends_on('trilinos')
 
     depends_on('nalu-wind+openfast', when='+openfast')
     depends_on('amr-wind+openfast', when='+openfast')

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -238,8 +238,7 @@ def use_develop_specs(env, specs):
 
     ev.activate(env)
     for spec_string in dev_specs:
-        print('spack manager develop ' + spec_string)
-        # special treatment for trilinos since if fails
+        # special treatment for trilinos since its clone fails
         # with standard spack develop
         if 'trilinos' in spec_string:
             branch = spec_string.split('@')[-1]

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -31,6 +31,7 @@ blacklist = ['cuda', 'cmake', 'yaml-cpp', 'rocm', 'llvm-admgpu', 'hip', 'py-']
 
 
 def command(command, *args):
+    print('spack', command.command_name, *args)
     print(command(*args, fail_on_error=False))
 
 

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -21,6 +21,7 @@ git = spack.util.executable.which('git')
 arch = spack.main.SpackCommand('arch')
 manager = spack.main.SpackCommand('manager')
 add = spack.main.SpackCommand('add')
+concretize = spack.main.SpackCommand('concretize')
 install = spack.main.SpackCommand('install')
 module = spack.main.SpackCommand('module')
 
@@ -226,11 +227,11 @@ def use_develop_specs(env, specs):
         # with standard spack develop
         if 'trilinos' in spec_string:
             branch = spec_string.split('@')[-1]
-            manager('develop', '-rb',
+            print(manager('develop', '-rb',
                     'https://github.com/trilinos/trilinos',
-                    branch, spec_string)
+                    branch, spec_string))
         else:
-            manager('develop', spec_string)
+            print(manager('develop', spec_string))
     ev.deactivate()
 
 
@@ -243,7 +244,7 @@ def create_snapshots(args):
     print('Creating snapshot environment')
     # we add cmake so it is a root spec that will get added to the view
     # so people using the snapshot don't have to rebuild
-    manager('create-env', '-d', env_path, '-s', 'cmake')
+    print(manager('create-env', '-d', env_path, '-s', 'cmake'))
     e = ev.Environment(env_path)
     with e.write_transaction():
         e.yaml['spack']['concretization'] = 'separately'
@@ -269,15 +270,14 @@ def create_snapshots(args):
 
     ev.activate(e)
     print('Concretize')
-    concrete_specs = e.concretize(force=True)
-    ev.display_specs(concrete_specs)
+    print(concretize('-f'))
     if args.stop_after == 'concretize':
         return
     print('Install')
-    install('-v')
+    print(install())
     if args.modules:
         print('Generate module files')
-        module('tcl', 'refresh', '-y')
+        print(module('tcl', 'refresh', '-y'))
 
 
 if __name__ == '__main__':

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -26,6 +26,8 @@ module = spack.main.SpackCommand('module')
 
 base_spec = 'exawind+hypre+openfast'
 
+blacklist = ['cuda', 'cmake', 'yaml-cpp', 'rocm', 'llvm-admgpu', 'hip', 'py-']
+
 
 class SnapshotSpec:
     def __init__(self, id='default', spec=base_spec):
@@ -124,7 +126,7 @@ def add_spec(env, extension, data, create_modules):
         syaml.dump(yaml, stream=f, default_flow_style=False)
 
 
-def get_top_level_specs(env, blacklist=['cmake', 'yaml-cpp']):
+def get_top_level_specs(env, blacklist=blacklist):
     env.concretize()
     top_specs = []
     for root in env.roots():
@@ -183,7 +185,7 @@ def replace_versions_with_hashes(spec_string, hash_dict):
     return final
 
 
-def use_latest_git_hashes(env, top_specs, blacklist=['cmake', 'yaml-cpp']):
+def use_latest_git_hashes(env, top_specs, blacklist=blacklist):
     with open(env.manifest_path, 'r') as f:
         yaml = syaml.load(f)
 

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -110,10 +110,11 @@ def get_top_level_specs(env, blacklist=['cmake', 'yaml-cpp']):
         for dep in root.dependencies():
             if dep.name not in blacklist:
                 top_specs.add(dep.format('{name}{@version}'))
+    print('Top Level Specs:', top_specs)
     return top_specs
 
 
-def find_latest_git_hash(env, spec_name):
+def find_latest_git_hash(env, spec_name, assign=False):
     spec = env.matching_spec(spec_name)
     version_dict = spec.package_class.version[spec.version]
     keys = version_dict.keys()
@@ -136,16 +137,14 @@ def find_latest_git_hash(env, spec_name):
     return sha
 
 
-def add_develop_specs(env):
+def add_develop_specs(env, dev_specs):
     # we have to concretize to solve the dependency tree to extract
     # the top level dependencies and make them develop specs.
     # anything that is not a develop spec is not gauranteed to get installed
     # since spack can reuse them for matching hashes
 
     print('Setting up develop specs')
-    dev_specs = get_top_level_specs(env)
 
-    print(dev_specs, len(dev_specs))
     ev.activate(env)
     for spec_string in dev_specs:
         print('spack manager develop ' + spec_string)
@@ -178,11 +177,14 @@ def create_snapshots(args):
 
     for s in spec_data:
         add_spec(e, extension, s, args.modules)
+
+    top_specs = get_top_level_specs(e)
+
     if args.stop_after == 'create_env':
         return
 
     if args.use_develop:
-        add_develop_specs(e)
+        add_develop_specs(e, top_specs)
 
     if args.stop_after == 'develop':
         return

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -6,7 +6,6 @@ and any associated modules
 
 import argparse
 import os
-import re
 import sys
 from manager_cmds.find_machine import find_machine
 
@@ -14,7 +13,6 @@ import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
 import spack.util.executable
-from spack.version import VersionList
 
 from datetime import date
 
@@ -58,9 +56,11 @@ def parse(stream):
         '--stop_after', '-sa', choices=phases,
         help='stop script after this phase')
     parser.add_argument('--use_develop', '-ud', action='store_true',
-                        help='use develop specs for roots and their immediate dependencies')
+                        help='use develop specs for roots and their immediate '
+                             'dependencies')
     parser.add_argument('--name', '-n', required=False,
-                        help='naem the environment something other than the date')
+                        help='naem the environment something other than the '
+                        'date')
     parser.set_defaults(modules=False, use_develop=False, stop_after='install')
 
     return parser.parse_args(stream)
@@ -109,7 +109,8 @@ def add_spec(env, extension, data, create_modules):
             'prefix_inspections': {'bin': ['PATH']},
             'roots': {'tcl': module_path},
             'arch_folder': False,
-            'tcl': {'projections': {'all': '%s/{name}-%s/{hash:4}' % (extension, data.id)},
+            'tcl': {'projections': {
+                    'all': '%s/{name}-%s/{hash:4}' % (extension, data.id)},
                     'hash_length': 0,
                     'blacklist_implicits': True,
                     'blacklist': ['cmake']}
@@ -152,8 +153,9 @@ def find_latest_git_hash(spec):
         # already matched
         return None
     else:
-        raise Exception('no known git type for ' +
-                        spec.format('//{hash} ({name}{@version})'))
+        raise Exception(
+            'no known git type for ' + spec.format(
+                '//{hash} ({name}{@version})'))
 
     # get the matching entry and shas for github
     query = git('ls-remote', spec.package.git, ref,
@@ -218,11 +220,13 @@ def use_develop_specs(env, specs):
     ev.activate(env)
     for spec_string in dev_specs:
         print('spack manager develop ' + spec_string)
-        # special treatment for trilinos since if fails with standard spack develop
+        # special treatment for trilinos since if fails
+        # with standard spack develop
         if 'trilinos' in spec_string:
             branch = spec_string.split('@')[-1]
             manager('develop', '-rb',
-                    'https://github.com/trilinos/trilinos', branch, spec_string)
+                    'https://github.com/trilinos/trilinos',
+                    branch, spec_string)
         else:
             manager('develop', spec_string)
     ev.deactivate()

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env spack-python
+"""
+This script will create the snapshots we need for the exawind project
+and any associated modules
+"""
+
+import argparse
+import os
+import sys
+from manager_cmds.find_machine import find_machine
+
+import spack.environment as ev
+import spack.main
+
+from datetime import date
+
+arch = spack.main.SpackCommand('arch')
+manager = spack.main.SpackCommand('manager')
+
+
+def parse(stream):
+    parser = argparse.ArgumentParser(
+        'create a timestamped snapshot for a Exawind machines')
+    parser.add_argument(
+        '-m', '--modules', action='store_true', help="create modules to associate with each view in the environment")
+    parser.set_defaults(modules=False)
+
+    return parser.parse_args(stream)
+
+
+def path_extension():
+    return "exawind/snapshots/{arch}/{date}".format(
+        date=date.today().strftime("%Y%m%d"),
+        arch=arch('-t'))
+
+
+# TODO embed this info into find_machine.py
+cuda_machines = ['eagle', 'ascicgpu']
+
+
+def add_specs(env, machine):
+
+    # ensure concretization is separate
+    env.yaml['spack']['concretization'] = 'separately'
+    specs = env.yaml['spack']['specs']
+    specs.append(
+        {'matrix': [['exawind+hypre+openfast+tioga'], ['~cuda']]}
+    )
+
+    # update matrix based on machine specific architecture
+    if machine in cuda_machines:
+        specs[-1]['matrix'][1].append(
+            '+cuda +amr_wind_gpu +nalu_wind_gpu cuda_arch=70')
+
+
+def add_views(env, machine, extension):
+    view = env.yaml['spack']['view']
+    prefix = os.path.join(os.environ['SPACK_MANAGER'], 'views')
+    # can we get away with just 1 view?
+    # todo link type as a parameter ?
+    view = {'base': {'root': os.path.join(prefix, extension, 'cpu'),
+                     'link_type': 'hardlink'}}
+
+
+def add_modules(env, machine, extension):
+    pass
+
+
+def create_snapshots(args):
+    machine = find_machine(verbose=False)
+    extension = path_extension()
+    env_path = os.path.join(
+        os.environ['SPACK_MANAGER'], 'environments', extension)
+
+    manager('create-env', '-d', env_path)
+    with ev.Environment(env_path) as e:
+        # update the spack.yaml in memory so we down't have to carry
+        # unnecessary templates for each machine
+        add_specs(e, machine)
+        add_views(e, machine, extension)
+        if args.modules:
+            add_modules(e, machine, extension)
+
+        # e.concretize()
+        # e.install_all()
+
+
+if __name__ == '__main__':
+    args = parse(sys.argv[1:])
+    create_snapshots(args)

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -12,8 +12,11 @@ from manager_cmds.find_machine import find_machine
 import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
+import spack.util.executable
 
 from datetime import date
+
+git = spack.util.executable.which('git')
 
 arch = spack.main.SpackCommand('arch')
 manager = spack.main.SpackCommand('manager')
@@ -44,14 +47,17 @@ machine_specs = {
 
 def parse(stream):
     parser = argparse.ArgumentParser(
-        'create a timestamped snapshot for a Exawind machines')
+        'create a timestamped snapshot for registered machines')
     parser.add_argument(
         '-m', '--modules', action='store_true',
-        help="create modules to associate with each view in the environment")
+        help='create modules to associate with each view in the environment')
+    phases = ['create_env', 'develop', 'concretize', 'install']
     parser.add_argument(
-        '--just-setup', action='store_true',
-        help='only create the environment, don\'t concretize or install')
-    parser.set_defaults(modules=False, just_setup=False)
+        '--stop_after', '-sa', choices=phases,
+        help='stop script after this phase')
+    parser.add_argument('--use_develop', '-ud', action='store_true',
+                        help='use develop specs for roots and their immediate dependencies')
+    parser.set_defaults(modules=False, use_develop=False, stop_after='install')
 
     return parser.parse_args(stream)
 
@@ -94,26 +100,62 @@ def add_spec(env, extension, data, create_modules):
         syaml.dump(yaml, stream=f, default_flow_style=False)
 
 
-def add_develop_specs(env, develop_blacklist=['cmake', 'yaml-cpp']):
+def get_top_level_specs(env, blacklist=['cmake', 'yaml-cpp']):
+    env.concretize()
+    top_specs = set()
+    for root in env.roots():
+        if root.name in blacklist:
+            continue
+        top_specs.add(root.format('{name}{@version}'))
+        for dep in root.dependencies():
+            if dep.name not in blacklist:
+                top_specs.add(dep.format('{name}{@version}'))
+    return top_specs
+
+
+def find_latest_git_hash(env, spec_name):
+    spec = env.matching_spec(spec_name)
+    version_dict = spec.package_class.version[spec.version]
+    keys = version_dict.keys()
+
+    if 'branch' in keys:
+        # git branch
+        ref = 'refs/heads/%s' % version_dict['branch']
+    elif 'tag' in keys:
+        ref = 'refs/tags/%s' % version_dict['tag']
+    elif 'sha256' in keys:
+        # already matched
+        return version_dict['sha256']
+
+    # get all the entries and shas for github
+    query = git('ls-remote', spec.package.git, ref,
+                output=str, error=str).strip().split('\n')
+    assert len(query) == 1
+
+    sha, _ = query[0].split('\t')
+    return sha
+
+
+def add_develop_specs(env):
     # we have to concretize to solve the dependency tree to extract
     # the top level dependencies and make them develop specs.
     # anything that is not a develop spec is not gauranteed to get installed
     # since spack can reuse them for matching hashes
 
     print('Setting up develop specs')
-    env.concretize()
-    dev_specs = set()
-    for root in env.roots():
-        dev_specs.add(root.format('{name}{@version}'))
-        for dep in root.dependencies():
-            if dep.name not in develop_blacklist:
-                dev_specs.add(dep.format('{name}{@version}'))
+    dev_specs = get_top_level_specs(env)
 
     print(dev_specs, len(dev_specs))
     ev.activate(env)
     for spec_string in dev_specs:
         print('spack manager develop ' + spec_string)
-        manager('develop', spec_string)
+        # special treatment for trilinos since if fails with standard spack develop
+        if 'trilinos' in spec_string:
+            branch = spec_string.split('@')[-1]
+            manager('develop', '-rb',
+                    'https://github.com/trilinos/trilinos', branch, spec_string)
+        else:
+            manager('develop', spec_string)
     ev.deactivate()
 
 
@@ -124,29 +166,36 @@ def create_snapshots(args):
         os.environ['SPACK_MANAGER'], 'environments', extension)
 
     print('Creating snapshot environment')
-    manager('create-env', '-d', env_path)
+    # we add cmake so it is a root spec that will get added to the view
+    # so people using the snapshot don't have to rebuild
+    manager('create-env', '-d', env_path, '-s', 'cmake')
     e = ev.Environment(env_path)
     with e.write_transaction():
         e.yaml['spack']['concretization'] = 'separately'
         e.write()
 
-    # update the spack.yaml in memory so we down't have to carry
-    # unnecessary templates for each machine
-
     spec_data = machine_specs[machine]
 
     for s in spec_data:
         add_spec(e, extension, s, args.modules)
+    if args.stop_after == 'create_env':
+        return
 
-    add_develop_specs(e)
-    if args.just_setup:
+    if args.use_develop:
+        add_develop_specs(e)
+
+    if args.stop_after == 'develop':
         return
 
     ev.activate(e)
-    #concrete_specs = e.concretize(force=True)
-    #ev.display_specs(concrete_specs)
-    concertize('-f')
-    install()
+    print('Concretize')
+    concrete_specs = e.concretize(force=True)
+    ev.display_specs(concrete_specs)
+    # concertize('-f')
+    if args.stop_after == 'concretize':
+        return
+    print('Install')
+    install('-v')
 
 
 if __name__ == '__main__':

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -129,7 +129,7 @@ def add_spec(env, extension, data, create_modules):
             'roots': {'tcl': module_path},
             'arch_folder': False,
             'tcl': {'projections': {
-                    'all': '%s/{name}-%s/{hash:4}' % (extension, data.id)},
+                    'all': '%s/{name}-%s' % (extension, data.id)},
                     'hash_length': 0,
                     'blacklist_implicits': True,
                     'blacklist': excludes}

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -31,11 +31,19 @@ blacklist = ['cuda', 'cmake', 'yaml-cpp', 'rocm', 'llvm-admgpu', 'hip', 'py-']
 
 
 def command(command, *args):
+    """
+    Execute a spack.main.SpackCommand uniformly
+    and add some print statements
+    """
     print('spack', command.command_name, *args)
     print(command(*args, fail_on_error=False))
 
 
 class SnapshotSpec:
+    """
+    Data structure for storing a tag that is not a hash
+    to represent the spec added to the spack.yaml
+    """
     def __init__(self, id='default', spec=base_spec):
         self.id = id
         self.spec = spec
@@ -235,11 +243,11 @@ def use_develop_specs(env, specs):
         # with standard spack develop
         if 'trilinos' in spec_string:
             branch = spec_string.split('@')[-1]
-            command(manager,'develop', '-rb',
+            command(manager, 'develop', '-rb',
                     'https://github.com/trilinos/trilinos',
                     branch, spec_string)
         else:
-            command(manager,'develop', spec_string)
+            command(manager, 'develop', spec_string)
     ev.deactivate()
 
 

--- a/scripts/snapshot-creator.py
+++ b/scripts/snapshot-creator.py
@@ -6,6 +6,7 @@ and any associated modules
 
 import argparse
 import os
+import re
 import sys
 from manager_cmds.find_machine import find_machine
 
@@ -13,6 +14,7 @@ import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
 import spack.util.executable
+from spack.version import VersionList
 
 from datetime import date
 
@@ -21,22 +23,22 @@ git = spack.util.executable.which('git')
 arch = spack.main.SpackCommand('arch')
 manager = spack.main.SpackCommand('manager')
 add = spack.main.SpackCommand('add')
-uninstall = spack.main.SpackCommand('uninstall')
-concertize = spack.main.SpackCommand('concretize')
 install = spack.main.SpackCommand('install')
+module = spack.main.SpackCommand('module')
 
 base_spec = 'exawind+hypre+openfast'
 
 
 class SnapshotSpec:
-    def __init__(self, id='host-only', spec=base_spec):
+    def __init__(self, id='default', spec=base_spec):
         self.id = id
         self.spec = spec
 
 
 # a list of specs to build in the snapshot, 1 view will be created for each
 machine_specs = {
-    'darwin': [SnapshotSpec(spec='exawind ^nccmp'), SnapshotSpec(id='default')],
+    'darwin': [SnapshotSpec()],
+    'snl-hpc': [SnapshotSpec()],
     'ascicgpu': [SnapshotSpec(),
                  SnapshotSpec(
                      id='cuda',
@@ -51,20 +53,22 @@ def parse(stream):
     parser.add_argument(
         '-m', '--modules', action='store_true',
         help='create modules to associate with each view in the environment')
-    phases = ['create_env', 'develop', 'concretize', 'install']
+    phases = ['create_env', 'mod_specs', 'concretize', 'install']
     parser.add_argument(
         '--stop_after', '-sa', choices=phases,
         help='stop script after this phase')
     parser.add_argument('--use_develop', '-ud', action='store_true',
                         help='use develop specs for roots and their immediate dependencies')
+    parser.add_argument('--name', '-n', required=False,
+                        help='naem the environment something other than the date')
     parser.set_defaults(modules=False, use_develop=False, stop_after='install')
 
     return parser.parse_args(stream)
 
 
-def path_extension():
+def path_extension(name):
     return "exawind/snapshots/{arch}/{date}".format(
-        date=date.today().strftime("%Y%m%d"),
+        date=name if name else date.today().strftime("%Y%m%d"),
         arch=arch('-t').strip())
 
 
@@ -96,6 +100,25 @@ def add_spec(env, extension, data, create_modules):
     except AttributeError:
         yaml['spack']['view'] = view_dict
 
+    if create_modules:
+        module_path = os.path.join(
+            os.environ['SPACK_MANAGER'], 'modules')
+        module_dict = {data.id: {
+            'enable': ['tcl'],
+            'use_view': data.id,
+            'prefix_inspections': {'bin': ['PATH']},
+            'roots': {'tcl': module_path},
+            'arch_folder': False,
+            'tcl': {'projections': {'all': '%s/{name}-%s/{hash:4}' % (extension, data.id)},
+                    'hash_length': 0,
+                    'blacklist_implicits': True,
+                    'blacklist': ['cmake']}
+        }}
+        try:
+            yaml['spack']['modules'].update(module_dict)
+        except KeyError:
+            yaml['spack']['modules'] = module_dict
+
     with open(env.manifest_path, 'w') as f:
         syaml.dump(yaml, stream=f, default_flow_style=False)
 
@@ -106,19 +129,17 @@ def get_top_level_specs(env, blacklist=['cmake', 'yaml-cpp']):
     for root in env.roots():
         if root.name in blacklist:
             continue
-        top_specs.append(root)  # .format('{name}{@version}'))
+        top_specs.append(root)
         for dep in root.dependencies():
             if dep.name not in blacklist:
-                top_specs.append(dep)  # .format('{name}{@version}'))
+                top_specs.append(dep)
     # remove any duplicates
     top_specs = list(dict.fromkeys(top_specs))
     print('Top Level Specs:', [s.name for s in top_specs])
     return top_specs
 
 
-def find_latest_git_hash(env, spec_name, assign=False):
-    print(spec_name)
-    spec = env.matching_spec(spec_name)
+def find_latest_git_hash(spec):
     version_dict = spec.package_class.versions[spec.version]
     keys = version_dict.keys()
 
@@ -129,29 +150,70 @@ def find_latest_git_hash(env, spec_name, assign=False):
         ref = 'refs/tags/%s' % version_dict['tag']
     elif 'sha256' in keys:
         # already matched
-        return version_dict['sha256']
+        return None
+    else:
+        raise Exception('no known git type for ' +
+                        spec.format('//{hash} ({name}{@version})'))
 
-    # get all the entries and shas for github
+    # get the matching entry and shas for github
     query = git('ls-remote', spec.package.git, ref,
                 output=str, error=str).strip().split('\n')
     assert len(query) == 1
 
     sha, _ = query[0].split('\t')
+
     return sha
 
 
-def overwrite_yaml_with_full_spec_and_git_hashes():
-    pass
-    #new = spec.format('{name}@')+ hash + spec.format('{variants}')
+def replace_versions_with_hashes(spec_string, hash_dict):
+    specs = str(spec_string).strip().split(' ^')
+    new_specs = []
+    for spec in specs:
+        base, rest = spec.split('%')
+        name, version = base.split('@')
+        hash = hash_dict.get(name)
+        if hash:
+            version = hash
+        new_specs.append('{n}@{v}%{r}'.format(n=name,
+                                              v=version, r=rest))
+    final = ' ^'.join(new_specs)
+    assert '\n' not in final
+    return final
 
 
-def add_develop_specs(env, dev_specs):
+def use_latest_git_hashes(env, top_specs, blacklist=['cmake', 'yaml-cpp']):
+    with open(env.manifest_path, 'r') as f:
+        yaml = syaml.load(f)
+
+    roots = list(env.roots())
+
+    for i in range(len(roots)):
+        if roots[i].name not in blacklist:
+            hash_dict = {}
+            hash_dict[roots[i].name] = find_latest_git_hash(roots[i])
+
+            for dep in roots[i].dependencies():
+                if dep.name not in blacklist:
+                    hash_dict[dep.name] = find_latest_git_hash(dep)
+
+            yaml['spack']['specs'][i] = replace_versions_with_hashes(
+                roots[i].build_spec, hash_dict)
+
+    with open(env.manifest_path, 'w') as fout:
+        syaml.dump_config(yaml, stream=fout,
+                          default_flow_style=False)
+    env._re_read()
+
+
+def use_develop_specs(env, specs):
     # we have to concretize to solve the dependency tree to extract
     # the top level dependencies and make them develop specs.
     # anything that is not a develop spec is not gauranteed to get installed
     # since spack can reuse them for matching hashes
 
     print('Setting up develop specs')
+    dev_specs = list(dict.fromkeys(
+        [s.format('{name}{@version}') for s in specs]))
 
     ev.activate(env)
     for spec_string in dev_specs:
@@ -168,7 +230,7 @@ def add_develop_specs(env, dev_specs):
 
 def create_snapshots(args):
     machine = find_machine(verbose=False)
-    extension = path_extension()
+    extension = path_extension(args.name)
     env_path = os.path.join(
         os.environ['SPACK_MANAGER'], 'environments', extension)
 
@@ -187,28 +249,29 @@ def create_snapshots(args):
         add_spec(e, extension, s, args.modules)
 
     top_specs = get_top_level_specs(e)
-    for s in top_specs:
-        h = find_latest_git_hash(e, s)
-        print(s.name, h)
 
     if args.stop_after == 'create_env':
         return
 
     if args.use_develop:
-        add_develop_specs(e, top_specs)
+        use_develop_specs(e, top_specs)
+    else:
+        use_latest_git_hashes(e, top_specs)
 
-    if args.stop_after == 'develop':
+    if args.stop_after == 'mod_specs':
         return
 
     ev.activate(e)
     print('Concretize')
     concrete_specs = e.concretize(force=True)
     ev.display_specs(concrete_specs)
-    # concertize('-f')
     if args.stop_after == 'concretize':
         return
     print('Install')
     install('-v')
+    if args.modules:
+        print('Generate module files')
+        module('tcl', 'refresh', '-y')
 
 
 if __name__ == '__main__':

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -21,8 +21,7 @@ spack:
 {includes}
   concretization: together
   view: false
-  specs:
-  - {spec}""")
+  specs: [{spec}]""")
 
 
 def create_env(parser, args):


### PR DESCRIPTION
Automated creation of snapshots for resuable binaries and modules: Closes #23 , closes #24 and closes #63 

This has two ways of creating the top level specs that we are tracking with fresh build: match the git hash (default) or make them develop specs.  Currently the default is broken.  Looks like the git sha as version feature in spack still needs some ironing out.  Until that gets fixed we can manually curate environments, or use the develop specs feature.