### PR TITLE
Use consistent floating point model for Intel compiler on Rhodes

### DIFF
--- a/configs/rhodes/compilers.yaml
+++ b/configs/rhodes/compilers.yaml
@@ -104,10 +104,10 @@ compilers:
     extra_rpaths:
      - /opt/compilers/2020-07/spack/opt/spack/linux-centos7-broadwell/gcc-8.4.0/intel-parallel-studio-cluster.2018.4-cykqqjzavipzalujhly6qtlgigoyvitb/compilers_and_libraries/linux/lib/intel64
      - /opt/compilers/2020-07/spack/opt/spack/linux-centos7-broadwell/gcc-8.4.0/gcc-8.4.0-26fck7zymxe7v7a7bpybuzqnq43klean/lib64
-    #flags:
-    #  cflags: -O2 -xCORE-AVX2
-    #  cxxflags: -O2 -xCORE-AVX2
-    #  fflags: -O2 -xCORE-AVX2
+    flags:
+      cflags: -fp-model consistent
+      cxxflags: -fp-model consistent
+      fflags: -fp-model consistent
     modules: []
     operating_system: centos7
     paths:


### PR DESCRIPTION
This removes the nondeterministic behavior encountered in testing Nalu-Wind on Rhodes when the Intel compiler uses SVML and whatever other floating point optimizations like vectorization that can be nondeterministic. This ruins performance so it's confined to Rhodes as a test machine and not for production runs.