### PR TITLE
Add reduced syntax developer work flow commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.code-workspace
 *.pyc
 .vscode
+.cache
+Configuring

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .vscode
 .cache
 Configuring
+.tmp/

--- a/configs/base/config.yaml
+++ b/configs/base/config.yaml
@@ -1,6 +1,6 @@
 config:
   source_cache: ~/.spack/downloads
-  misc_cache: $spack/../cache
+  misc_cache: $spack/../.cache
   build_stage:
     - $spack/../stage
   concretizer: clingo

--- a/scripts/create-developer-env.sh
+++ b/scripts/create-developer-env.sh
@@ -12,10 +12,10 @@ set -e
 printf "Starting at $(date).\n"
 
 if [[ -z ${SPACK_MANAGER} ]]; then
-    printf "\nSPACK_MANAGER not set so setting it to ${PWD}\n"
-    cmd "export SPACK_MANAGER=${PWD}"
+  printf "\nSPACK_MANAGER not set so setting it to ${PWD}\n"
+  cmd "export SPACK_MANAGER=${PWD}"
 else
-    printf "\nSPACK_MANAGER set to ${SPACK_MANAGER}\n"
+  printf "\nSPACK_MANAGER set to ${SPACK_MANAGER}\n"
 fi
 
 printf "\nActivating Spack-Manager...\n"
@@ -37,9 +37,14 @@ elif [ "${SPACK_MANAGER_MACHINE}" == 'rhodes' ]; then
   DEV_COMMAND='spack manager develop nalu-wind@master; spack manager develop hypre@develop'
   VIEW="${COMPILER}"
 fi
-cmd "spack manager create-env --directory ${SPACK_MANAGER}/environments/exawind --spec "${SPEC}""
+# all of these commands will eventually be combined into
+# quick-develop --name --exawind --spec $SPEC hypre@develop
+# still missing view selection for this
+
+# updated to use the new --name flag
+cmd "spack manager create-env --name exawind --spec "${SPEC}""
 cmd "spack env activate -d ${SPACK_MANAGER}/environments/exawind"
-cmd "spack config add config:concretizer:original"
+# if you do develop first then it will now auto-blacklist those specs for you
 cmd "spack manager external ${SNAPSHOT_DIR} -v ${VIEW} --blacklist ${BLACKLIST}"
 cmd "${DEV_COMMAND}"
 cmd "spack concretize -f"

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -9,6 +9,7 @@ import os
 import sys
 from manager_cmds.find_machine import find_machine
 import multiprocessing
+from manager_utils import path_extension
 
 import spack.environment as ev
 import spack.main
@@ -16,11 +17,9 @@ import spack.util.spack_yaml as syaml
 import spack.util.executable
 import spack.cmd.install
 
-from datetime import date
 
 git = spack.util.executable.which('git')
 
-arch = spack.main.SpackCommand('arch')
 manager = spack.main.SpackCommand('manager')
 add = spack.main.SpackCommand('add')
 concretize = spack.main.SpackCommand('concretize')
@@ -119,17 +118,6 @@ def parse(stream):
     parser.set_defaults(modules=False, use_develop=False, stop_after='install')
 
     return parser.parse_args(stream)
-
-
-def path_extension(name, use_machine_name):
-    if use_machine_name:
-        return "exawind/snapshots/{machine}/{date}".format(
-            date=name if name else date.today().strftime("%Y-%m-%d"),
-            machine=os.environ['SPACK_MANAGER_MACHINE'])
-    else:
-        return "exawind/snapshots/{arch}/{date}".format(
-            date=name if name else date.today().strftime("%Y-%m-%d"),
-            arch=arch('-b').strip())
 
 
 def view_excludes(snap_spec):

--- a/scripts/test_developer_workflow.py
+++ b/scripts/test_developer_workflow.py
@@ -45,7 +45,6 @@ env_path = os.path.join(os.environ['SPACK_MANAGER'],
                         'environments', args.dev_name)
 command(manager, 'create-env', '--directory', env_path, '--spec', 'nalu-wind')
 ev.activate(ev.Environment(env_path))
-command(config, 'add', 'config:concretizer:original')
 command(manager, 'external', snapshot_path, '-v', args.view_name,
         '--blacklist', 'nalu-wind')
 command(manager, 'develop', 'nalu-wind@master')

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -47,6 +47,11 @@ function quick-develop() {
     printf "\nERROR: Exiting quick-develop prematurely\n"
     return 1
   fi
+  cmd "spack manager external --latest"
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-develop prematurely\n"
+    return 1
+  fi
   cmd "spack concretize -f"
   if [[ $? != 0 ]]; then
     printf "\nERROR: Exiting quick-develop prematurely\n"

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -26,7 +26,14 @@ function quick-develop() {
   #set -e
 
   cmd "spack-start"
-  cmd "swspack manager create-dev-env $* -a"
+  cmd "swspack manager create-dev-env $* -a" 2>/tmp/Error
+  ERROR=$(</tmp/Error)
+  echo "$ERROR"
+  if [[ "$ERROR" == *"All specs must be concrete:"* ]]; then
+    echo "An error occured in setting your environment. Please make sure all spack specs have valid spack versions i.e. [name]@[version]"
+    cmd "spack env deactivate"
+    exit 1
+  fi
   cmd "spack concretize -f"
   cmd "spack install"
 }

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -13,3 +13,11 @@ function swspack() {
   spack_command="spack $@"
   eval "$(${spack_command})"
 }
+# function to create, activate, concretize and attempt to install a develop environment all in one step
+function quick-develop() {
+  set -e
+  spack-start
+  swspack manager create-dev-env "$@" -a
+  spack concretize
+  spack install
+}

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -1,19 +1,15 @@
 # function to initialize spack-manager's spack instance
-function spack-start(){
+function spack-start() {
   source ${SPACK_MANAGER}/start.sh
 }
 # function to quickly activate an environment
-function quick-activate(){
+function quick-activate() {
   spack-start
   spack env activate -p -d $1
 }
 # function to wrap spack manager calls for shell modification
 # i.e. shell-wrapped-spack
-function swspack(){
+function swspack() {
   spack_command="spack $@"
-  if [[ "$*" == *create-env* && "$*" == *-a* ]]; then
-    eval $( ${spack_command} )
-  else
-    eval ${spack_command}
-  fi
+  eval "$(${spack_command})"
 }

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -1,39 +1,56 @@
+cmd() {
+  echo "+ $@"
+  eval "$@"
+}
 # function to initialize spack-manager's spack instance
 function spack-start() {
   source ${SPACK_MANAGER}/start.sh
 }
 # function to quickly activate an environment
 function quick-activate() {
-  spack-start
-  spack env activate -p -d $1
+  cmd "spack-start"
+  cmd "spack env activate -p -d $1"
 }
-# function to wrap spack manager calls for shell modification
-# i.e. shell-wrapped-spack
-function swspack() {
-  spack_command="spack $@"
-  eval "$(${spack_command})"
+# convenience function for quickly creating an environment
+# and activating it in the current shell
+function quick-create() {
+  cmd "spack-start"
+  cmd "spack manager create-env $@"
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-create prematurely\n"
+    return 1
+  fi
+  EPATH=$(cat $SPACK_MANAGER/.tmp/created_env_path.txt)
+  cmd "spack env activate --dir ${EPATH} --prompt"
 }
 # function to create, activate, concretize and attempt to install a develop environment all in one step
 function quick-develop() {
   # Trap and kill background processes
   trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-  cmd() {
-    echo "+ $@"
-    eval "$@"
-  }
-
-  #set -e
+  # since we want this to run in the active shell
+  # we mush manually return instead of exiting with set -e
 
   cmd "spack-start"
-  cmd "swspack manager create-dev-env $* -a" 2>/tmp/Error
-  ERROR=$(</tmp/Error)
-  echo "$ERROR"
-  if [[ "$ERROR" == *"All specs must be concrete:"* ]]; then
-    echo "An error occured in setting your environment. Please make sure all spack specs have valid spack versions i.e. [name]@[version]"
-    cmd "spack env deactivate"
-    exit 1
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-develop prematurely\n"
+    return 1
+  fi
+  cmd "spack manager create-dev-env $*"
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-develop prematurely\n"
+    return 1
+  fi
+  EPATH=$(cat $SPACK_MANAGER/.tmp/created_env_path.txt)
+  cmd "spack env activate --dir ${EPATH} --prompt"
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-develop prematurely\n"
+    return 1
   fi
   cmd "spack concretize -f"
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-develop prematurely\n"
+    return 1
+  fi
   cmd "spack install"
 }

--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -15,9 +15,18 @@ function swspack() {
 }
 # function to create, activate, concretize and attempt to install a develop environment all in one step
 function quick-develop() {
-  set -e
-  spack-start
-  swspack manager create-dev-env "$@" -a
-  spack concretize
-  spack install
+  # Trap and kill background processes
+  trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+  cmd() {
+    echo "+ $@"
+    eval "$@"
+  }
+
+  #set -e
+
+  cmd "spack-start"
+  cmd "swspack manager create-dev-env $* -a"
+  cmd "spack concretize -f"
+  cmd "spack install"
 }

--- a/spack-scripting/scripting/cmd/manager.py
+++ b/spack-scripting/scripting/cmd/manager.py
@@ -1,5 +1,6 @@
 import sys
 
+import manager_cmds.create_dev_env
 import manager_cmds.create_env
 import manager_cmds.develop
 import manager_cmds.external
@@ -20,6 +21,7 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='spack-manager commands',
                                   dest='manager_command')
     manager_cmds.create_env.add_command(sp, _subcommands)
+    manager_cmds.create_dev_env.add_command(sp, _subcommands)
     manager_cmds.develop.add_command(sp, _subcommands)
     manager_cmds.find_machine.add_command(sp, _subcommands)
     manager_cmds.external.add_command(sp, _subcommands)

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -22,6 +22,10 @@ def create_dev_env(parser, args):
 	env = ev.Environment(env_path)
 	ev.activate(env)
 	for s in args.spec:
+		if '@' not in s:
+			print(
+				'All specs must be concrete to use create-dev-env i.e. at least [name]@[version]')
+			exit(1)
 		if 'trilinos' not in s:
 			develop(s)
 		else:

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -1,5 +1,5 @@
 import argparse
-
+import sys
 import manager_cmds.create_env as create_env
 import manager_cmds.develop
 
@@ -24,7 +24,7 @@ def create_dev_env(parser, args):
 	for s in args.spec:
 		print("\tCalling spack manager develop for", s)
 		if '@' not in s:
-			print(
+			sys.stderr.write(
 				'All specs must be concrete to use create-dev-env i.e. at least [name]@[version]')
 			exit(1)
 		if 'trilinos' not in s:
@@ -32,7 +32,7 @@ def create_dev_env(parser, args):
 		else:
 			develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
 	if args.print_path:
-		print('Env created at:', env_path)
+		print('Env created at:\n', env_path)
 
 
 def add_command(parser, command_dict):

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -11,19 +11,16 @@ def develop(args):
     """
     wrapper around manager.develop
     """
-    parser = argparse.ArgumentParser('dummy')
+    parser = argparse.ArgumentParser('develop')
     sub_parser = parser.add_subparsers()
     manager_cmds.develop.add_command(sub_parser, {})
-    args = parser.parse_args(['develop', args])
+    args = parser.parse_args(['develop', *args])
     manager_cmds.develop.manager_develop(parser, args)
 
 
 def create_dev_env(parser, args):
-    env_path = create_env.create_env(parser, args)
-    env = ev.Environment(env_path)
-    ev.activate(env)
     for s in args.spec:
-        print("\tCalling spack manager develop for", s)
+        # check that all specs were concrete
         if '@' not in s:
             sys.stderr.write(
                 '\nERROR: All specs must be concrete to use '
@@ -33,12 +30,24 @@ def create_dev_env(parser, args):
                 '\nSome common exawind versions are: exawind@master, '
                 'amr-wind@main and nalu-wind@master\n')
             exit(1)
-        if 'trilinos' not in s:
-            develop(s)
-        else:
-            develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
-    if args.print_path:
-        print('Env created at:\n', env_path)
+    env_path = create_env.create_env(parser, args)
+    env = ev.Environment(env_path)
+    ev.activate(env)
+    for s in env.user_specs:
+        dev_args = []
+        # kind of hacky, but spack will try to re-clone
+        # if we don't give the --path argument even though
+        # it is already in the spack.yaml
+        if env.is_develop(s) and 'path' in env.yaml[
+                'spack']['develop'][str(s.name)]:
+            dev_args.extend([
+                '--path', env.yaml['spack']['develop'][str(s.name)]['path']])
+        if 'trilinos' in str(s.name):
+            dev_args.extend(['-rb', 'git@github.com:trilinos/trilinos.git',
+                             str(s.version)])
+        dev_args.append(str(s))
+        develop(dev_args)
+    ev.deactivate()
 
 
 def add_command(parser, command_dict):
@@ -47,7 +56,4 @@ def add_command(parser, command_dict):
         help='create a developer focused environment where all root specs are'
         ' develop specs')
     create_env.setup_parser_args(sub_parser)
-    sub_parser.add_argument('-p', '--print_path', action='store_true',
-                            help='print the environment location to the command line')
-    sub_parser.set_defaults(print_path=False)
     command_dict['create-dev-env'] = create_dev_env

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -22,6 +22,7 @@ def create_dev_env(parser, args):
 	env = ev.Environment(env_path)
 	ev.activate(env)
 	for s in args.spec:
+		print("\tCalling spack manager develop for", s)
 		if '@' not in s:
 			print(
 				'All specs must be concrete to use create-dev-env i.e. at least [name]@[version]')
@@ -30,10 +31,15 @@ def create_dev_env(parser, args):
 			develop(s)
 		else:
 			develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
+	if args.print_path:
+		print('Env created at:', env_path)
 
 
 def add_command(parser, command_dict):
 	sub_parser = parser.add_parser(
 		'create-dev-env', help='create a developer focused environment where all root specs are develop specs')
 	create_env.setup_parser_args(sub_parser)
+	sub_parser.add_argument('-p', '--print_path', action='store_true',
+	                        help='print the environment location to the command line')
+	sub_parser.set_defaults(print_path=False)
 	command_dict['create-dev-env'] = create_dev_env

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -25,7 +25,12 @@ def create_dev_env(parser, args):
 		print("\tCalling spack manager develop for", s)
 		if '@' not in s:
 			sys.stderr.write(
-				'All specs must be concrete to use create-dev-env i.e. at least [name]@[version]')
+				'\nERROR: All specs must be concrete to use '
+				'\'spack manager create-dev-env\' i.e. at '
+				'least [package]@[version].\nTo learn what versions are'
+				' available type \'spack info [package]\''
+				'\nSome common exawind versions are: exawind@master, '
+				'amr-wind@main and nalu-wind@master\n')
 			exit(1)
 		if 'trilinos' not in s:
 			develop(s)

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+
 import manager_cmds.create_env as create_env
 import manager_cmds.develop
 
@@ -7,44 +8,46 @@ import spack.environment as ev
 
 
 def develop(args):
-	"""
-	wrapper around manager.develop
-	"""
-	parser = argparse.ArgumentParser('dummy')
-	sub_parser = parser.add_subparsers()
-	manager_cmds.develop.add_command(sub_parser, {})
-	args = parser.parse_args(['develop', args])
-	manager_cmds.develop.manager_develop(parser, args)
+    """
+    wrapper around manager.develop
+    """
+    parser = argparse.ArgumentParser('dummy')
+    sub_parser = parser.add_subparsers()
+    manager_cmds.develop.add_command(sub_parser, {})
+    args = parser.parse_args(['develop', args])
+    manager_cmds.develop.manager_develop(parser, args)
 
 
 def create_dev_env(parser, args):
-	env_path = create_env.create_env(parser, args)
-	env = ev.Environment(env_path)
-	ev.activate(env)
-	for s in args.spec:
-		print("\tCalling spack manager develop for", s)
-		if '@' not in s:
-			sys.stderr.write(
-				'\nERROR: All specs must be concrete to use '
-				'\'spack manager create-dev-env\' i.e. at '
-				'least [package]@[version].\nTo learn what versions are'
-				' available type \'spack info [package]\''
-				'\nSome common exawind versions are: exawind@master, '
-				'amr-wind@main and nalu-wind@master\n')
-			exit(1)
-		if 'trilinos' not in s:
-			develop(s)
-		else:
-			develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
-	if args.print_path:
-		print('Env created at:\n', env_path)
+    env_path = create_env.create_env(parser, args)
+    env = ev.Environment(env_path)
+    ev.activate(env)
+    for s in args.spec:
+        print("\tCalling spack manager develop for", s)
+        if '@' not in s:
+            sys.stderr.write(
+                '\nERROR: All specs must be concrete to use '
+                '\'spack manager create-dev-env\' i.e. at '
+                'least [package]@[version].\nTo learn what versions are'
+                ' available type \'spack info [package]\''
+                '\nSome common exawind versions are: exawind@master, '
+                'amr-wind@main and nalu-wind@master\n')
+            exit(1)
+        if 'trilinos' not in s:
+            develop(s)
+        else:
+            develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
+    if args.print_path:
+        print('Env created at:\n', env_path)
 
 
 def add_command(parser, command_dict):
-	sub_parser = parser.add_parser(
-		'create-dev-env', help='create a developer focused environment where all root specs are develop specs')
-	create_env.setup_parser_args(sub_parser)
-	sub_parser.add_argument('-p', '--print_path', action='store_true',
-	                        help='print the environment location to the command line')
-	sub_parser.set_defaults(print_path=False)
-	command_dict['create-dev-env'] = create_dev_env
+    sub_parser = parser.add_parser(
+        'create-dev-env',
+        help='create a developer focused environment where all root specs are'
+        ' develop specs')
+    create_env.setup_parser_args(sub_parser)
+    sub_parser.add_argument('-p', '--print_path', action='store_true',
+                            help='print the environment location to the command line')
+    sub_parser.set_defaults(print_path=False)
+    command_dict['create-dev-env'] = create_dev_env

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -1,0 +1,35 @@
+import argparse
+
+import manager_cmds.create_env as create_env
+import manager_cmds.develop
+
+import spack.environment as ev
+
+
+def develop(args):
+	"""
+	wrapper around manager.develop
+	"""
+	parser = argparse.ArgumentParser('dummy')
+	sub_parser = parser.add_subparsers()
+	manager_cmds.develop.add_command(sub_parser, {})
+	args = parser.parse_args(['develop', args])
+	manager_cmds.develop.manager_develop(parser, args)
+
+
+def create_dev_env(parser, args):
+	env_path = create_env.create_env(parser, args)
+	env = ev.Environment(env_path)
+	ev.activate(env)
+	for s in args.spec:
+		if 'trilinos' not in s:
+			develop(s)
+		else:
+			develop('-rb', 'git@github.com:trilinos/trilinos.git', 'develop', s)
+
+
+def add_command(parser, command_dict):
+	sub_parser = parser.add_parser(
+		'create-dev-env', help='create a developer focused environment where all root specs are develop specs')
+	create_env.setup_parser_args(sub_parser)
+	command_dict['create-dev-env'] = create_dev_env

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -11,6 +11,7 @@ from manager_cmds.find_machine import find_machine
 from manager_cmds.includes_creator import IncludesCreator
 
 import spack.util.spack_yaml as syaml
+from spack.config import merge_yaml
 
 default_env_file = (
     """
@@ -25,13 +26,10 @@ def create_env(parser, args):
     if args.yaml:
         assert(os.path.isfile(args.yaml))
         with open(args.yaml, 'r') as fyaml:
-            yaml = syaml.load_config(fyaml)
-        # if user hasn't explicitly set view and concretization
-        # set them for them
-        if 'view' not in yaml['spack']:
-            yaml['spack']['view'] = False
-        if 'concretization' not in yaml['spack']:
-            yaml['spack']['concretization'] = 'together'
+            user_yaml = syaml.load_config(fyaml)
+        # merge defaults and user yaml files precedent to user specified
+        defaults = syaml.load_config(default_env_file)
+        yaml = merge_yaml(defaults, user_yaml)
     else:
         yaml = syaml.load_config(default_env_file)
 
@@ -85,8 +83,11 @@ def create_env(parser, args):
         syaml.dump_config(yaml, stream=f, default_flow_style=False)
 
     fpath = os.path.join(os.environ['SPACK_MANAGER'], '.tmp')
+
     os.makedirs(fpath, exist_ok=True)
+
     storage = os.path.join(fpath, 'created_env_path.txt')
+
     with open(storage, 'w') as f:
         f.write(theDir)
 

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -89,6 +89,7 @@ def create_env(parser, args):
     storage = os.path.join(fpath, 'created_env_path.txt')
     with open(storage, 'w') as f:
         f.write(theDir)
+
     return theDir
 
 

--- a/spack-scripting/scripting/cmd/manager_cmds/develop.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/develop.py
@@ -73,7 +73,7 @@ def manager_develop(parser, args):
         git_clone(branch, repo, path)
         args.clone = False
 
-    spack_develop.develop(parser, args)
+    spack_develop.develop(None, args)
 
 
 def add_command(parser, command_dict):

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -137,6 +137,10 @@ def external(parser, args):
     env = ev.active_environment()
     if not env:
         tty.die('spack manager external requires an active environment')
+    # for now we have to use the original concretizer
+    # see: https://github.com/spack/spack/issues/28201
+    env.yaml['spack']['config'] = {'concretizer': 'original'}
+    env.write()
     if args.latest:
         snap_path = get_latest_dated_snapshot()
         if not snap_path:

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -1,8 +1,9 @@
 import os
-from datetime import datetime
-from manager_utils import base_extension
 import re
 import sys
+from datetime import datetime
+
+from manager_utils import base_extension
 
 import llnl.util.tty as tty
 
@@ -25,7 +26,8 @@ def get_external_dir():
     if os.path.isdir(external_machine) and os.path.isdir(external_arch):
         raise Exception(
             'ERROR: Snapshots based on arch and machine are both valid. '
-            'Please contact system admins and spack-manager maintainers to sort this out')
+            'Please contact system admins and spack-manager maintainers'
+            ' to sort this out')
 
     if os.path.isdir(external_arch):
         external = external_arch

--- a/spack-scripting/scripting/cmd/manager_utils.py
+++ b/spack-scripting/scripting/cmd/manager_utils.py
@@ -1,5 +1,5 @@
-from datetime import date
 import os
+from datetime import date
 
 import spack.main
 

--- a/spack-scripting/scripting/cmd/manager_utils.py
+++ b/spack-scripting/scripting/cmd/manager_utils.py
@@ -1,0 +1,20 @@
+from datetime import date
+import os
+
+import spack.main
+
+arch = spack.main.SpackCommand('arch')
+
+
+def base_extension(use_machine_name):
+    if use_machine_name:
+        return "exawind/snapshots/{machine}".format(
+            machine=os.environ['SPACK_MANAGER_MACHINE'])
+    else:
+        return "exawind/snapshots/{arch}".format(
+            arch=arch('-b').strip())
+
+
+def path_extension(name, use_machine_name):
+    return os.path.join(base_extension(use_machine_name), "{date}".format(
+        date=name if name else date.today().strftime("%Y-%m-%d")))

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import patch
+
+import manager_cmds.create_dev_env
+import pytest
+
+import spack.main
+
+manager = spack.main.SpackCommand('manager')
+
+
+def test_allSpecsCallSpackDevelop(tmpdir):
+	with tmpdir.as_cwd():
+		with patch("manager_cmds.create_dev_env.develop") as mock_dev:
+			manager('create-dev-env', '-s', 'amr-wind@main',
+			        'nalu-wind@master', 'exawind@master')
+		mock_dev.assert_any_call('amr-wind@main')
+		mock_dev.assert_any_call('nalu-wind@master')
+		mock_dev.assert_any_call('exawind@master')
+
+
+def test_newEnvironmentIsCreated(tmpdir):
+	with tmpdir.as_cwd():
+		with patch("manager_cmds.create_dev_env.develop") as mock_dev:
+			manager('create-dev-env', '-s', 'amr-wind@main',
+			        'nalu-wind@master', 'exawind@master')
+		assert os.path.isfile(tmpdir.join('spack.yaml'))
+		assert os.path.isfile(tmpdir.join('include.yaml'))

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -58,8 +58,9 @@ def test_newEnvironmentKeepingUserSpecifiedYAML(mock_dev, tmpdir):
         assert 'path' in e.yaml['spack']['develop']['nalu-wind']
         # mocked out call that would update yaml with trilinos info but
         # assuming it works fine
-        mock_dev.assert_any_call(['amr-wind@main'])
-        mock_dev.assert_any_call(['nalu-wind@master'])
+        mock_dev.assert_any_call(['--path', amr_path.strpath, 'amr-wind@main'])
+        mock_dev.assert_any_call(
+            ['--path', nalu_path.strpath, 'nalu-wind@master'])
         mock_dev.assert_called_with([
             '-rb', 'git@github.com:trilinos/trilinos.git',
             'master', 'trilinos@master'])

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -1,28 +1,25 @@
 import os
 from unittest.mock import patch
 
-import manager_cmds.create_dev_env
-import pytest
-
 import spack.main
 
 manager = spack.main.SpackCommand('manager')
 
 
 def test_allSpecsCallSpackDevelop(tmpdir):
-	with tmpdir.as_cwd():
-		with patch("manager_cmds.create_dev_env.develop") as mock_dev:
-			manager('create-dev-env', '-s', 'amr-wind@main',
-			        'nalu-wind@master', 'exawind@master')
-		mock_dev.assert_any_call('amr-wind@main')
-		mock_dev.assert_any_call('nalu-wind@master')
-		mock_dev.assert_any_call('exawind@master')
+    with tmpdir.as_cwd():
+        with patch("manager_cmds.create_dev_env.develop") as mock_dev:
+            manager('create-dev-env', '-s', 'amr-wind@main',
+                    'nalu-wind@master', 'exawind@master')
+        mock_dev.assert_any_call('amr-wind@main')
+        mock_dev.assert_any_call('nalu-wind@master')
+        mock_dev.assert_any_call('exawind@master')
 
 
 def test_newEnvironmentIsCreated(tmpdir):
-	with tmpdir.as_cwd():
-		with patch("manager_cmds.create_dev_env.develop") as mock_dev:
-			manager('create-dev-env', '-s', 'amr-wind@main',
-			        'nalu-wind@master', 'exawind@master')
-		assert os.path.isfile(tmpdir.join('spack.yaml'))
-		assert os.path.isfile(tmpdir.join('include.yaml'))
+    with tmpdir.as_cwd():
+        with patch("manager_cmds.create_dev_env.develop"):
+            manager('create-dev-env', '-s', 'amr-wind@main',
+                    'nalu-wind@master', 'exawind@master')
+        assert os.path.isfile(tmpdir.join('spack.yaml'))
+        assert os.path.isfile(tmpdir.join('include.yaml'))

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import patch
 
+import spack.environment as ev
 import spack.main
 
 manager = spack.main.SpackCommand('manager')
@@ -11,9 +12,9 @@ def test_allSpecsCallSpackDevelop(tmpdir):
         with patch("manager_cmds.create_dev_env.develop") as mock_dev:
             manager('create-dev-env', '-s', 'amr-wind@main',
                     'nalu-wind@master', 'exawind@master')
-        mock_dev.assert_any_call('amr-wind@main')
-        mock_dev.assert_any_call('nalu-wind@master')
-        mock_dev.assert_any_call('exawind@master')
+        mock_dev.assert_any_call(['amr-wind@main'])
+        mock_dev.assert_any_call(['nalu-wind@master'])
+        mock_dev.assert_any_call(['exawind@master'])
 
 
 def test_newEnvironmentIsCreated(tmpdir):
@@ -23,3 +24,42 @@ def test_newEnvironmentIsCreated(tmpdir):
                     'nalu-wind@master', 'exawind@master')
         assert os.path.isfile(tmpdir.join('spack.yaml'))
         assert os.path.isfile(tmpdir.join('include.yaml'))
+
+
+@patch('manager_cmds.create_dev_env.develop')
+def test_newEnvironmentKeepingUserSpecifiedYAML(mock_dev, tmpdir):
+    with tmpdir.as_cwd():
+        amr_path = tmpdir.join('test_amr-wind')
+        nalu_path = tmpdir.join('test_nalu-wind')
+        os.makedirs(amr_path.strpath)
+        os.makedirs(nalu_path.strpath)
+        assert os.path.isdir(amr_path.strpath)
+        assert os.path.isdir(nalu_path.strpath)
+        user_spec_yaml = """spack:
+  develop:
+     amr-wind:
+       spec: amr-wind@main
+       path: {amr}
+     nalu-wind:
+       spec: nalu-wind@master
+       path: {nalu}""".format(amr=amr_path.strpath, nalu=nalu_path.strpath)
+        with open(tmpdir.join('user.yaml'), 'w') as yaml:
+            yaml.write(user_spec_yaml)
+
+        print(manager('create-dev-env', '-d', tmpdir.strpath, '-s',
+                      'amr-wind@main', 'nalu-wind@master', 'trilinos@master', '-y',
+                      str(tmpdir.join('user.yaml')), fail_on_error=False))
+        e = ev.Environment(tmpdir.strpath)
+        print(e.yaml)
+        print(list(e.user_specs))
+        assert os.path.isfile(str(tmpdir.join('spack.yaml')))
+        assert os.path.isfile(str(tmpdir.join('include.yaml')))
+        assert 'path' in e.yaml['spack']['develop']['amr-wind']
+        assert 'path' in e.yaml['spack']['develop']['nalu-wind']
+        # mocked out call that would update yaml with trilinos info but
+        # assuming it works fine
+        mock_dev.assert_any_call(['amr-wind@main'])
+        mock_dev.assert_any_call(['nalu-wind@master'])
+        mock_dev.assert_called_with([
+            '-rb', 'git@github.com:trilinos/trilinos.git',
+            'master', 'trilinos@master'])

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -52,3 +52,30 @@ def test_missingReferenceYamlFilesDontBreakEnv(monkeypatch):
         # ensure that this environment can be created
         # missing includes will cause a failure
         env.Environment(tmpdir)
+
+
+def test_specsCanBeAddedToExisitingYaml(tmpdir):
+    with tmpdir.as_cwd():
+        preset_yaml = """
+spack:
+  develop:
+    amr-wind:
+      spec: amr-wind@main
+      path: /tst/dir"""
+
+        with open('test.yaml', 'w') as fyaml:
+            fyaml.write(preset_yaml)
+
+        env_root = str(tmpdir.join('dev'))
+        os.makedirs(env_root)
+
+        manager('create-env', '-d', env_root, '-m', 'darwin',
+                '-y', 'test.yaml', '-s', 'amr-wind', 'nalu-wind')
+
+        e = env.Environment(env_root)
+        assert e.yaml['spack']['specs'][0] == 'amr-wind'
+        assert e.yaml['spack']['specs'][1] == 'nalu-wind'
+        assert e.yaml['spack']['develop']['amr-wind']['spec'] == 'amr-wind@main'
+        assert e.yaml['spack']['develop']['amr-wind']['path'] == '/tst/dir'
+        assert not e.yaml['spack']['view']
+        assert e.yaml['spack']['concretization'] == 'together'

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -52,24 +52,3 @@ def test_missingReferenceYamlFilesDontBreakEnv(monkeypatch):
         # ensure that this environment can be created
         # missing includes will cause a failure
         env.Environment(tmpdir)
-
-
-def test_envIsActivatedWithActivateFlag(monkeypatch):
-    with TemporaryDirectory() as tmpdir:
-        # setup a mirror configuration of spack-manager
-        link_dir = os.path.join(os.environ['SPACK_MANAGER'], 'configs', 'base')
-
-        os.mkdir(os.path.join(tmpdir, 'configs'))
-        os.symlink(link_dir,
-                   os.path.join(tmpdir, 'configs', 'base'))
-
-        # monkeypatches
-        envVars = {'SPACK_MANAGER': tmpdir}
-        monkeypatch.setattr(os, 'environ', envVars)
-
-        manager('create-env', '-d', tmpdir, '-a')
-
-        assert env.active_environment() is not None
-        assert env.active_environment().path == tmpdir
-        # this is required for clean up. need to start using spack test decorators
-        env.deactivate()

--- a/spack-scripting/tests/test_external.py
+++ b/spack-scripting/tests/test_external.py
@@ -26,13 +26,16 @@ class ParserMock:
                  name='externals.yaml',
                  whitelist=None,
                  blacklist=None,
-                 merge=False):
+                 merge=False,
+                 latest=False):
         self.path = path
         self.view = view
         self.name = name
         self.whitelist = whitelist
         self.blacklist = blacklist
         self.merge = merge
+        self.latest = False
+        self.list = False
 
 
 def setupExternalEnv(tmpdir, has_view=True):

--- a/start.sh
+++ b/start.sh
@@ -22,6 +22,9 @@ export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
 export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd
 source ${SPACK_ROOT}/share/spack/setup-env.sh
 
+# Clean Spack misc caches
+spack clean -m
+
 if [[ -z $(spack config --scope site blame config | grep spack-scripting) ]]; then
     spack config --scope site add config:extensions:[${SPACK_MANAGER}/spack-scripting]
 fi
@@ -31,6 +34,3 @@ if [[ "${SPACK_MANAGER_MACHINE}" == "NOT-FOUND" ]]; then
     echo "Machine not found."
 fi
 export PATH=${PATH}:${SPACK_MANAGER}/scripts
-
-# Clean Spack misc caches
-spack clean -m

--- a/start.sh
+++ b/start.sh
@@ -18,7 +18,7 @@ fi
 ########################################################
 export SPACK_ROOT=${SPACK_MANAGER}/spack
 export SPACK_DISABLE_LOCAL_CONFIG=true
-export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/cache
+export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
 export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd
 source ${SPACK_ROOT}/share/spack/setup-env.sh
 


### PR DESCRIPTION
The current full process for setting up a development environment is:

1. `spack-start` (setup commands for the shell, source spack)
2. `spack create-env` to create the specific environment 
3. `spack env activate` to activate the environment
4. `spack add` to add the packages you want in the environment
5. `spack manager develop` to declare which specs are develop specs and clone the repos
6. `spack manager external` to link your build to external pre-curated installs
7. `spack concretize` to solve the dependencies
8. `spack install` to build the environment

This is pretty verbose and allows complete customization of the environments, but it is a lot of commands and is tedious for everyday use.  This PR will reduce the workflow quite a bit. 

Step 4 `spack add` has pretty much been eliminated in this PR by allowing users to specify multiple full specs from the command line i.e. 
```shell
# spack manager create-env -s nalu-wind amr-wind
```
  or 
```shell
# spack manager create-env -s 'nalu-wind build_type=Debug' amr-wind
```

Commands add in reduced developer workflows:

- Introducing the new command `spack manager create-dev-env` that makes it so all specs are develop specs. This encompasses steps 3, 5 and 6

Two new convenience functions in `$SPACK_MANAGER/scripts/useful_bash_functions.sh`

- `quick-create` handles steps 1-4 (when using multiple specs at the command line)
- `quick-develop` handles steps 1-8 all in one
- If a user wants to specify pre-cloned repos going into these functions they can do so with a minimal yaml file. Our commands will now merge this yaml file's contents with our template to create a valid `spack.yaml`.  Note the user's supplied yaml file gets precedent so things like `concretization: together` and `view: false` can be overridden.
   ```yaml
   spack:
     develop:
        amr-wind:
           spec: amr-wind@main
           path: /path/to/the/pre/clone/amr
        nalu-wind:
           spec: nalu-wind@master
           path: /path/to/the/pre/clone/nalu
        exawind:
           spec: exawind@master
           path: /path/to/the/pre/clone/exawind-driver
     ```

both of these convenience functions just take the arguments from `spack manager create-env` and `spack manager create-dev-env` respectively.

TODO:

- [x] Give a way for users to give pre-cloned repos to `spack manager create-dev-env`
- [x] Add a way to specify externals at `spack manager create*env` commands

Bonus: 

-   adding the `-n` or `--name` flags to the `create-env` commands which will create the environment at `$SPACK_MANAGER/environments/[name]` which reduces uncertainty on where to put the environment files.  The `--directory` flag which allows you to put the environment where ever you want.
- auto using the original concretizer when adding an external via `spack manager external`
- auto blacklisting develop specs when using `spack manager external`