### PR TITLE
Workflow improvements

### DIFF
--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -32,6 +32,22 @@ function quick-create() {
   cmd "spack env activate --dir ${EPATH} --prompt"
 }
 
+# same as quick-create but calls create-env-dev instead
+# can be used to add externals
+function quick-create-dev() {
+  cmd "spack-start"
+  cmd "spack manager create-env-dev $@"
+  if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    return
+  fi
+  if [[ $? != 0 ]]; then
+    printf "\nERROR: Exiting quick-create prematurely\n"
+    return 1
+  fi
+  EPATH=$(cat $SPACK_MANAGER/.tmp/created_env_path.txt)
+  cmd "spack env activate --dir ${EPATH} --prompt"
+}
+
 # function to create, activate, concretize and attempt to install a develop environment all in one step
 function quick-develop() {
   # since we want this to run in the active shell

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -34,7 +34,6 @@ def get_external_dir():
     else:
         external = external_machine
 
-    print(external)
     if os.path.isdir(external):
         return external
     else:
@@ -134,6 +133,16 @@ def create_external_yaml_from_env(path, view_key, black_list, white_list):
 
 
 def external(parser, args):
+    if args.list:
+        extern_dir = get_external_dir()
+        snaps = get_all_snapshots()
+        print('Available snapshot directories (and views) are: ')
+        for s in snaps:
+            env_dir = os.path.join(extern_dir, s)
+            env = ev.Environment(env_dir)
+            views = ', '.join(env.views.keys())
+            print(' - {path} ({views})'.format(path=env_dir, views=views))
+        return
     env = ev.active_environment()
     if not env:
         tty.die('spack manager external requires an active environment')
@@ -152,13 +161,6 @@ def external(parser, args):
             return
     else:
         snap_path = args.path
-    if args.list:
-        extern_dir = get_external_dir()
-        snaps = get_all_snapshots()
-        print("Available snapshot directories are: ")
-        for s in snaps:
-            print('\t' + os.path.join(extern_dir, s))
-        return
 
     # check that directory of ext view exists
     if not ev.is_env_dir(snap_path):


### PR DESCRIPTION
I realized `quick-develop` won't work on eagle and other multi view per external platforms.  This adds the views to the print statement of `spack manager external --list` and it adds a `quick-create-dev` which does the same thing as `quick-develop` but stops the workflow right before adding the externals so users can do that manually for now.