### PR TITLE
Fix some bugs with auto external detection

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -29,8 +29,6 @@ def get_external_dir():
             'Please contact system admins and spack-manager maintainers'
             ' to sort this out')
 
-    print(external_machine)
-    print(external_arch)
     if os.path.isdir(external_arch):
         external = external_arch
     else:
@@ -62,7 +60,6 @@ def get_latest_dated_snapshot():
     base_dir = get_external_dir()
     # remove anything that isn't a date stamp i.e. (custom snapshots)
     if base_dir and snapshots:
-        print(base_dir)
         dates = [d for d in snapshots if re.search(r'\d{4}-\d{2}-\d{2}', d)]
         dates.sort(reverse=True, key=lambda date: datetime.strptime(
             date, "%Y-%m-%d"))

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -29,6 +29,8 @@ def get_external_dir():
             'Please contact system admins and spack-manager maintainers'
             ' to sort this out')
 
+    print(external_machine)
+    print(external_arch)
     if os.path.isdir(external_arch):
         external = external_arch
     else:
@@ -59,9 +61,14 @@ def get_latest_dated_snapshot():
     snapshots = get_all_snapshots()
     base_dir = get_external_dir()
     # remove anything that isn't a date stamp i.e. (custom snapshots)
-    dates = [d for d in snapshots if re.search(r'\d{4}-\d{2}-\d{2}', d)]
-    dates.sort(reverse=True, key=lambda date: datetime.strptime(date, "%Y-%m-%d"))
-    return os.path.join(base_dir, dates[0])
+    if base_dir and snapshots:
+        print(base_dir)
+        dates = [d for d in snapshots if re.search(r'\d{4}-\d{2}-\d{2}', d)]
+        dates.sort(reverse=True, key=lambda date: datetime.strptime(
+            date, "%Y-%m-%d"))
+        return os.path.join(base_dir, dates[0])
+    else:
+        return
 
 
 def include_entry_exists(env, name):
@@ -106,7 +113,7 @@ def create_external_yaml_from_env(path, view_key, black_list, white_list):
     env.check_views()
     if view_key is None:
         # get the first view that was added to the environment as the default
-        view_key = env.views.keys()[0]
+        view_key = list(env.views.keys())[0]
 
     try:
         view = env.views[view_key]
@@ -157,11 +164,11 @@ def external(parser, args):
     if args.latest:
         snap_path = get_latest_dated_snapshot()
         if not snap_path:
-            sys.stderr.write('WARNING: No \'externals.yaml\' created because no valid '
-                             'snapshots were found. \n'
-                             '\tIf you are trying to use a system level snapshot make '
-                             'sure you have SPACK_MANAGER_EXTERNAL pointing to '
-                             'spack-manager directory for the system.\n')
+            print('WARNING: No \'externals.yaml\' created because no valid '
+                  'snapshots were found. \n'
+                  '  If you are trying to use a system level snapshot make '
+                  'sure you have SPACK_MANAGER_EXTERNAL pointing to '
+                  'spack-manager directory for the system.\n')
             return
     else:
         snap_path = args.path

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 from datetime import datetime
 
 from manager_utils import base_extension

--- a/start.sh
+++ b/start.sh
@@ -33,5 +33,7 @@ export SPACK_MANAGER_MACHINE=$(spack manager find-machine)
 if [[ "${SPACK_MANAGER_MACHINE}" == "NOT-FOUND" ]]; then
     echo "Machine not found."
 fi
-export SPACK_MANAGER_EXTERNAL=$(${SPACK_MANAGER}/scripts/supported_external_paths.py)
+if [[ -n "$(${SPACK_MANAGER}/scripts/supported_external_paths.py)" ]]; then
+    export SPACK_MANAGER_EXTERNAL=$(${SPACK_MANAGER}/scripts/supported_external_paths.py)
+fi
 export PATH=${PATH}:${SPACK_MANAGER}/scripts


### PR DESCRIPTION
I found a couple of bugs with the external detection.

- The env var `SPACK_MANAGER_EXTERNAL` was getting set on any machine and it should only happen automatically for the ones we've setup
- We want this to be a warning when it is missing not an error.