### PR TITLE
ASCICGPU: Config update

### DIFF
--- a/configs/ascicgpu/compilers.yaml
+++ b/configs/ascicgpu/compilers.yaml
@@ -1,5 +1,18 @@
 compilers:
 - compiler:
+    spec: gcc@9.3.0
+    paths:
+      cc: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gcc
+      cxx: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/g++
+      f77: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gfortran
+      fc: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     environment: {}
     extra_rpaths:
     - /opt/rh/devtoolset-8/root/usr/lib64

--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -2,23 +2,88 @@ packages:
   all:
     compiler: [gcc]
     providers:
-      mpi: [openmpi]
+      mpi: [mpich]
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
     variants: build_type=Release
     target: [x86_64]
   cmake:
     externals:
-    - spec: cmake@3.20.0
-      modules:
-      - sierra-cmake/3.20.0
-      prefix: /projects/sierra/linux_rh7/install/cmake/3.20.0/bin/cmake
-  openmpi:
+    - spec: cmake@3.22.2
+      prefix: /projects/wind/spack-manager/views/system/gcc-4.8.5/cmake-3.22.2
+    buildable: false
+  ncurses:
     externals:
-    - spec: openmpi@4.0.5
-      modules:
-      - sierra-mpi/openmpi/4.0.5
-      prefix: /projects/sierra/linux_rh7/SDK/mpi/openmpi/4.0.5-nvidia-11.2.1-RHEL7/
+    - spec: ncurses@6.2%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/ncurses-6.2
+    buildable: false
+  openssl:
+    externals:
+    - spec: openssl@1.1.1m%gcc@4.8.5
+      prefix: /projects/wind/spack-manager/views/system/gcc-4.8.5/openssl-1.1.1m
+    buildable: false
+  zlib:
+    externals:
+    - spec: zlib@1.2.11%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/zlib-1.2.11
+    buildable: false
+  mpich:
+    externals:
+    - spec: mpich@3.4.2%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/mpich-3.4.2
+    buildable: false
+  hwloc:
+    externals:
+    - spec: hwloc@2.7.0%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/hwloc-2.7.0
+    buildable: false
+  libpciaccess:
+    externals:
+    - spec: libpciaccess@0.16%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libpciaccess-0.16
+    buildable: false
+  libxml2:
+    externals:
+    - spec: libxml2@2.9.12%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libxml2-2.9.12
+    buildable: false
+  libiconv:
+    externals:
+    - spec: libiconv@1.16%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libiconv-1.16
+    buildable: false
+  xz:
+    externals:
+    - spec: xz@5.2.5%gcc@9.3.0~pic
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/xz-5.2.5
+    buildable: false
+  libfabric:
+    externals:
+    - spec: libfabric@1.14.0%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libfabric-1.14.0
     buildable: false
   cuda:
-    version: [11.2.1]
+    externals:
+    - spec: cuda@11.2.2%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/cuda-11.2.2
+    buildable: false
+  binutils:
+    externals:
+    - spec: binutils@2.37%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/binutils-2.37
+    buildable: false
+  gettext:
+    externals:
+    - spec: gettext@0.21%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/gettext-0.21
+    buildable: false
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.8%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/bzip2-1.0.8
+    buildable: false
+  tar:
+    externals:
+    - spec: tar@1.34%gcc@9.3.0
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/tar-1.34
+    buildable: false

--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -10,7 +10,7 @@ packages:
   cmake:
     externals:
     - spec: cmake@3.22.2
-      prefix: /projects/wind/spack-manager/views/system/gcc-4.8.5/cmake-3.22.2
+      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/cmake-3.22.2
     buildable: false
   ncurses:
     externals:

--- a/env-templates/system_externals.yaml
+++ b/env-templates/system_externals.yaml
@@ -4,25 +4,21 @@ spack:
   - system_specs:
     - cmake
     - mpich%gcc@9.3.0
+
   - when: env['SPACK_MANAGER_MACHINE']=='ascicgpu'
     system_specs: [cuda@11.2.2%gcc@9.3.0]
-
-  - when: env['SPACK_MANAGER_MACHINE']=='darwin'
-    system_specs: [gcc@9.3.0]
-
-  - when: env['SPACK_MANAGER_MACHINE']!='darwin'
-    system_specs: [gcc@9.3.0+binutils+piclibs]
-
   specs:
   - $system_specs
+  - binutils
+  - cuda@11.2.2
   view:
     default:
       root: /projects/wind/spack-manager/views/system
       projections:
-        all: '{compiler.name}-{compiler.version/}{name}-{version}'
+        all: '{compiler.name}-{compiler.version}/{name}-{version}'
       link_type: hardlink
   config:
-    install_missing_compilers: true
+    concretizer: original
   packages:
     all:
       target: [x86_64]

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -89,10 +89,9 @@ machine_specs = {
                             '+cuda+amr_wind_gpu+nalu_wind_gpu '
                             'cuda_arch=70 %gcc')],
     'snl-hpc': [SnapshotSpec()],
-    'ascicgpu': [
-                 SnapshotSpec(
+    'ascicgpu': [SnapshotSpec(
                      'gcc-cuda', base_spec + '+cuda+amr_wind_gpu+nalu_wind_gpu'
-                     ' cuda_arch=70'), SnapshotSpec(id='gcc'),],
+                     ' cuda_arch=70'), SnapshotSpec(id='gcc'), ],
 }
 
 

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -89,9 +89,9 @@ machine_specs = {
                             '+cuda+amr_wind_gpu+nalu_wind_gpu '
                             'cuda_arch=70 %gcc')],
     'snl-hpc': [SnapshotSpec()],
-    'ascicgpu': [SnapshotSpec(
-                     'gcc-cuda', base_spec + '+cuda+amr_wind_gpu+nalu_wind_gpu'
-                     ' cuda_arch=70'), SnapshotSpec(id='gcc'), ],
+    'ascicgpu': [SnapshotSpec('gcc-cuda', base_spec + '+cuda+amr_wind_gpu'
+                              '+nalu_wind_gpu cuda_arch=70'),
+                 SnapshotSpec(id='gcc'), ],
 }
 
 

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -89,10 +89,10 @@ machine_specs = {
                             '+cuda+amr_wind_gpu+nalu_wind_gpu '
                             'cuda_arch=70 %gcc')],
     'snl-hpc': [SnapshotSpec()],
-    'ascicgpu': [SnapshotSpec(),
+    'ascicgpu': [
                  SnapshotSpec(
-                     'cuda', base_spec + '+cuda+amr_wind_gpu+nalu_wind_gpu'
-                     ' cuda_arch=70')],
+                     'gcc-cuda', base_spec + '+cuda+amr_wind_gpu+nalu_wind_gpu'
+                     ' cuda_arch=70'), SnapshotSpec(id='gcc'),],
 }
 
 

--- a/spack-scripting/scripting/manager_utils.py
+++ b/spack-scripting/scripting/manager_utils.py
@@ -1,0 +1,20 @@
+import os
+from datetime import date
+
+import spack.main
+
+arch = spack.main.SpackCommand('arch')
+
+
+def base_extension(use_machine_name):
+    if use_machine_name:
+        return "exawind/snapshots/{machine}".format(
+            machine=os.environ['SPACK_MANAGER_MACHINE'])
+    else:
+        return "exawind/snapshots/{arch}".format(
+            arch=arch('-b').strip())
+
+
+def path_extension(name, use_machine_name):
+    return os.path.join(base_extension(use_machine_name), "{date}".format(
+        date=name if name else date.today().strftime("%Y-%m-%d")))

--- a/start.sh
+++ b/start.sh
@@ -19,7 +19,7 @@ fi
 export SPACK_ROOT=${SPACK_MANAGER}/spack
 export SPACK_DISABLE_LOCAL_CONFIG=true
 export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
-export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd
+export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd:${SPACK_MANAGER}/spack-scripting/scripting
 source ${SPACK_ROOT}/share/spack/setup-env.sh
 
 # Clean Spack misc caches

--- a/tests/ci_config_concretization.py
+++ b/tests/ci_config_concretization.py
@@ -25,18 +25,20 @@ def check_config_concretizations(name, ref_yaml):
 
 def run_tests(args):
     failure = False
-    machine_names = list(machine_list.keys())
-    matrix_test_machines = ['eagle', 'summit']
     this_machine = find_machine(verbose=False)
-
-    if '_matrix.yaml' in args.yaml:
-        machine_names = matrix_test_machines
+    # only test darwin on matching ci platform
+    if this_machine == 'darwin':
+        machine_names = ['darwin']
     else:
-        machine_names = list(set(machine_names) - set(matrix_test_machines))
-    # remove from ascicgpu from darwin due to gcc conflict
-    # need to test if we can move to boost@1.77
-    if this_machine == 'darwin' and 'ascicgpu' in machine_names:
-        machine_names.remove('ascicgpu')
+        machine_names = list(machine_list.keys())
+        machine_names.remove('darwin')
+        matrix_test_machines = ['eagle', 'summit']
+
+        if '_matrix.yaml' in args.yaml:
+            machine_names = matrix_test_machines
+        else:
+            machine_names = list(set(machine_names) -
+                                 set(matrix_test_machines))
 
     for name in machine_names:
         try:

--- a/tests/ci_config_concretization.py
+++ b/tests/ci_config_concretization.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env spack-python
 from tempfile import TemporaryDirectory
+import manager_cmds.find_machine as find_machine
 from manager_cmds.find_machine import machine_list
 import spack.environment as env
 import spack.main
@@ -26,11 +27,16 @@ def run_tests(args):
     failure = False
     machine_names = list(machine_list.keys())
     matrix_test_machines = ['eagle', 'summit']
+    this_machine = find_machine(verbose=False)
 
     if '_matrix.yaml' in args.yaml:
         machine_names = matrix_test_machines
     else:
         machine_names = list(set(machine_names) - set(matrix_test_machines))
+    # remove from ascicgpu from darwin due to gcc conflict
+    # need to test if we can move to boost@1.77
+    if this_machine == 'darwin' and 'ascicgpu' in machine_names:
+        machine_names.remove('ascicgpu')
 
     for name in machine_names:
         try:

--- a/tests/ci_config_concretization.py
+++ b/tests/ci_config_concretization.py
@@ -37,8 +37,8 @@ def run_tests(args):
         if '_matrix.yaml' in args.yaml:
             machine_names = matrix_test_machines
         else:
-            machine_names = list(set(machine_names) -
-                                 set(matrix_test_machines))
+            machine_names = list(
+                set(machine_names) - set(matrix_test_machines))
 
     for name in machine_names:
         try:


### PR DESCRIPTION
Update ascicgpu to use compilers matching eagle. These compilers and externals were built with spack using the environment described by [env-templates/system_externals.yaml](https://github.com/psakievich/spack-manager/blob/main/env-templates/system_externals.yaml).

Closes #148 