### PR TITLE
Remove clean phase from hypre

### DIFF
--- a/repos/exawind/packages/hypre/package.py
+++ b/repos/exawind/packages/hypre/package.py
@@ -3,13 +3,6 @@ from spack.pkg.builtin.hypre import Hypre as bHypre
 import os
 
 class Hypre(bHypre):
-
-    phases = ['autoreconf', 'configure', 'clean', 'build', 'install']
-
-    def clean(self, spec, prefix):
-        with working_dir('src'):
-            make('clean')
-
     def _configure_args(self):
         spec = self.spec
         options = super(Hypre, self)._configure_args()                        


### PR DESCRIPTION
Hypre PR https://github.com/hypre-space/hypre/pull/574 should hopefully let us remove the `make clean` phase when using hypre as a develop spec.