### PR TITLE
Make execution match help for create-dev-env

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -3,6 +3,7 @@ import argparse
 import manager_cmds.create_env as create_env
 import manager_cmds.develop
 
+import spack.cmd
 import spack.environment as ev
 
 
@@ -21,9 +22,10 @@ def create_dev_env(parser, args):
     env_path = create_env.create_env(parser, args)
     env = ev.Environment(env_path)
     ev.activate(env)
-    for s in env.user_specs:
+    specs = spack.cmd.parse_specs(args.spec)
+    for s in specs:
         # check that all specs were concrete
-        if not s.concrete:
+        if not s.versions.concrete:
             print('\nWarning: {spec} is not concrete and will not '
                   'be setup as a develop spec.'
                   '\nAll specs must be concrete for '
@@ -32,6 +34,7 @@ def create_dev_env(parser, args):
                   ' available type \'spack info [package]\''
                   '\nSome common exawind versions are: exawind@master, '
                   'amr-wind@main and nalu-wind@master\n'.format(spec=s))
+            continue
         dev_args = []
         # kind of hacky, but spack will try to re-clone
         # if we don't give the --path argument even though

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -3,8 +3,6 @@ import argparse
 import manager_cmds.create_env as create_env
 import manager_cmds.develop
 
-import llnl.util.tty as tty
-
 import spack.environment as ev
 
 
@@ -20,24 +18,20 @@ def develop(args):
 
 
 def create_dev_env(parser, args):
-    if not args.spec:
-        tty.die(
-            '\nERROR: specs are a required argument for '
-            'spack manager create-dev-env.\n')
-    for s in args.spec:
-        # check that all specs were concrete
-        if '@' not in s:
-            tty.die(
-                '\nERROR: All specs must be concrete to use '
-                '\'spack manager create-dev-env\' i.e. at '
-                'least [package]@[version].\nTo learn what versions are'
-                ' available type \'spack info [package]\''
-                '\nSome common exawind versions are: exawind@master, '
-                'amr-wind@main and nalu-wind@master\n')
     env_path = create_env.create_env(parser, args)
     env = ev.Environment(env_path)
     ev.activate(env)
     for s in env.user_specs:
+        # check that all specs were concrete
+        if not s.concrete:
+            print('\nWarning: {spec} is not concrete and will not '
+                  'be setup as a develop spec.'
+                  '\nAll specs must be concrete for '
+                  '\'spack manager create-dev-env\' to clone for you i.e. at '
+                  'least [package]@[version].\nTo learn what versions are'
+                  ' available type \'spack info [package]\''
+                  '\nSome common exawind versions are: exawind@master, '
+                  'amr-wind@main and nalu-wind@master\n'.format(spec=s))
         dev_args = []
         # kind of hacky, but spack will try to re-clone
         # if we don't give the --path argument even though

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -76,3 +76,13 @@ def test_nonConcreteSpecsDontGetCloned(mock_dev, tmpdir):
         assert 'nalu-wind' in e.yaml['spack']['specs']
         assert 'exawind@master' in e.yaml['spack']['specs']
         assert 'amr-wind' in e.yaml['spack']['specs']
+
+
+@patch('manager_cmds.create_dev_env.develop')
+def test_noSpecsIsNotAnErrorGivesBlankEnv(mock_develop, tmpdir):
+    with tmpdir.as_cwd():
+        manager('create-dev-env', '-d', tmpdir.strpath)
+        assert not mock_develop.called
+        e = ev.Environment(tmpdir.strpath)
+        assert len(e.user_specs) == 0
+        assert e.yaml['spack']['specs'] == []

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -64,3 +64,15 @@ def test_newEnvironmentKeepingUserSpecifiedYAML(mock_dev, tmpdir):
         mock_dev.assert_called_with([
             '-rb', 'git@github.com:trilinos/trilinos.git',
             'master', 'trilinos@master'])
+
+
+@patch('manager_cmds.create_dev_env.develop')
+def test_nonConcreteSpecsDontGetCloned(mock_dev, tmpdir):
+    with tmpdir.as_cwd():
+        manager('create-dev-env', '-s', 'amr-wind', 'nalu-wind',
+                'exawind@master', '-d', tmpdir.strpath)
+        mock_dev.assert_called_once_with(['exawind@master'])
+        e = ev.Environment(tmpdir.strpath)
+        assert 'nalu-wind' in e.yaml['spack']['specs']
+        assert 'exawind@master' in e.yaml['spack']['specs']
+        assert 'amr-wind' in e.yaml['spack']['specs']


### PR DESCRIPTION
As outlined in #164 `spack manager create-dev-env` is not consistent with the `--help` prompt.  This makes it so it is not an error to omit specs or to give non-concrete specs. However, non-concrete specs won't be made into develop specs and automatically cloned.  A warning message will be printed for each of these specs.

Closes #164 