### PR TITLE
Perform shell checks on useful_bash_functions.sh

### DIFF
--- a/scripts/useful_bash_functions.sh
+++ b/scripts/useful_bash_functions.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+########################################################
+# Tests same as start.sh for now
+########################################################
+if [[ -z ${SPACK_MANAGER} ]]; then
+  echo "ERROR: Env variable SPACK_MANAGER not set. You must set this variable."
+  return 1
+fi
+
+if [[ ! -x $(which python3) ]]; then
+  echo "WARNING: spack-manager is only designed to work with python 3."
+  echo "You may use spack, but spack-manager specific commands will fail."
+fi
+
 cmd() {
   echo "+ $@"
   eval "$@"

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@
 ########################################################
 if [[ -z ${SPACK_MANAGER} ]]; then
     echo "Env variable SPACK_MANAGER not set. You must set this variable."
-    exit 125
+    return 1
 fi
 
 if [[ ! -x $(which python3) ]]; then


### PR DESCRIPTION
This performs the same shell checks on the `useful_bash_functions.sh` as we use in `start.sh` due to the corner case outlined in #163 .  It would be nice if we could just auto set `$SPACK_MANAGER` using the location of the script.  I started looking into this rabbit hole, but it seems like there are too many corner cases: 

https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
https://stackoverflow.com/questions/24112727/relative-paths-based-on-file-location-instead-of-current-working-directory

I think it is safest to just put this burden on the users.  I also made these errors return instead of exit since this is a sourced script so it would kill people's login shell before they can see the error message. (Infinite loop of frustration).

Closes #163