### PR TITLE
New gcc9 compiler on ascicgpu

### DIFF
--- a/configs/ascicgpu/compilers.yaml
+++ b/configs/ascicgpu/compilers.yaml
@@ -2,10 +2,10 @@ compilers:
 - compiler:
     spec: gcc@9.3.0
     paths:
-      cc: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gcc
-      cxx: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/g++
-      f77: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gfortran
-      fc: /projects/wind/spack-manager/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-63a5fxv3jfmvgwr2gf4kqdtsa3k3bly6/bin/gfortran
+      cc: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gcc
+      cxx: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/g++
+      f77: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gfortran
+      fc: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gfortran
     flags: {}
     operating_system: rhel7
     target: x86_64

--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -10,80 +10,15 @@ packages:
   cmake:
     externals:
     - spec: cmake@3.22.2
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/cmake-3.22.2
-    buildable: false
-  ncurses:
-    externals:
-    - spec: ncurses@6.2%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/ncurses-6.2
-    buildable: false
-  openssl:
-    externals:
-    - spec: openssl@1.1.1m%gcc@4.8.5
-      prefix: /projects/wind/spack-manager/views/system/gcc-4.8.5/openssl-1.1.1m
-    buildable: false
-  zlib:
-    externals:
-    - spec: zlib@1.2.11%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/zlib-1.2.11
+      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/cmake-3.22.2-s67tgoaqaw4ky5kmpuzxdg5une7xouvh/
     buildable: false
   mpich:
     externals:
     - spec: mpich@3.4.2%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/mpich-3.4.2
-    buildable: false
-  hwloc:
-    externals:
-    - spec: hwloc@2.7.0%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/hwloc-2.7.0
-    buildable: false
-  libpciaccess:
-    externals:
-    - spec: libpciaccess@0.16%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libpciaccess-0.16
-    buildable: false
-  libxml2:
-    externals:
-    - spec: libxml2@2.9.12%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libxml2-2.9.12
-    buildable: false
-  libiconv:
-    externals:
-    - spec: libiconv@1.16%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libiconv-1.16
-    buildable: false
-  xz:
-    externals:
-    - spec: xz@5.2.5%gcc@9.3.0~pic
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/xz-5.2.5
-    buildable: false
-  libfabric:
-    externals:
-    - spec: libfabric@1.14.0%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/libfabric-1.14.0
-    buildable: false
+      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/
+    - spec: mpich@3.4.2%gcc@8.3.1
+      prefix: /projects/wind/spack-manager/views/system/gcc-8.3.1/mpich-3.4.2
   cuda:
     externals:
     - spec: cuda@11.2.2%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/cuda-11.2.2
-    buildable: false
-  binutils:
-    externals:
-    - spec: binutils@2.37%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/binutils-2.37
-    buildable: false
-  gettext:
-    externals:
-    - spec: gettext@0.21%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/gettext-0.21
-    buildable: false
-  bzip2:
-    externals:
-    - spec: bzip2@1.0.8%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/bzip2-1.0.8
-    buildable: false
-  tar:
-    externals:
-    - spec: tar@1.34%gcc@9.3.0
-      prefix: /projects/wind/spack-manager/views/system/gcc-9.3.0/tar-1.34
-    buildable: false
+      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/cuda-11.2.2-wlah7an4q7rej4uylqlimczaa6z3zlq7/

--- a/env-templates/system_externals.yaml
+++ b/env-templates/system_externals.yaml
@@ -7,10 +7,10 @@ spack:
 
   - when: env['SPACK_MANAGER_MACHINE']=='ascicgpu'
     system_specs: [cuda@11.2.2%gcc@9.3.0]
+  - when: env['SPACK_MANAGER_MACHINE'] not 'darwin'
+    system_specs: [binutils+ld]
   specs:
   - $system_specs
-  - binutils
-  - cuda@11.2.2
   view:
     default:
       root: /projects/wind/spack-manager/views/system


### PR DESCRIPTION
Try using compiler and externals from separate spack install.  I've tested this with `amr-wind+cuda cuda_arch=70` on ascicgpu057 and ascicgpu22 since trilinos was failing on me due to the SEACAS bug.  So far it is all building fine from my profiles.  

I built this compiler with `+binutils` which seems to have taken care of the issues we were seeing with the last one.

Right now I've only built TPL's (cuda, mpich, openmpi) with gcc@9.3.0 but I can build them for gcc@8.3.1 and other compilers later if this is working for the STK team.

I've also removed `~/.spack` and run `spack clean -a` before building to try and make sure it wasn't succeeding due to some cache in my environments.  However, I'd still like a replication from @tasmith4 before merging.

Closes #179 