### PR TITLE
use actual hostnames for SNL machines

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -41,11 +41,11 @@ match
 machine_list = {
     # SNL
     'cee': MachineData(lambda: is_cee(socket.gethostname()),
-                       'cee.snl.gov'),
+                       socket.gethostname()),
     'snl-hpc': MachineData(lambda: is_snl_hpc(socket.gethostname()),
-                           'snl-hpc.snl.gov'),
+                           socket.gethostname()),
     'ascicgpu': MachineData(lambda: 'ascicgpu' in socket.gethostname(),
-                            'ascicgpu.snl.gov'),
+                            socket.gethostname()),
     # NREL
     'eagle': MachineData(lambda: os.environ['NREL_CLUSTER'] == 'eagle',
                          'eagle.hpc.nrel.gov'),


### PR DESCRIPTION
It seems like the full machine name in MachineData is only used for text output, so we can just use the actual hostname, at least for SNL machines.

@psakievich or @jrood-nrel please speak up if I'm missing something and this won't work.