### PR TITLE
Posix compliant type check on `_spack_start_called` function

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $(type -t _spack_start_called) != function ]]; then
+if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   export SPACK_ROOT=${SPACK_MANAGER}/spack
   export SPACK_DISABLE_LOCAL_CONFIG=true
   export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache


### PR DESCRIPTION
According to [this](https://unix.stackexchange.com/questions/332005/test-for-functions-existence-that-can-work-on-both-bash-and-zsh), `type -t` is not posix compliant. And indeed it breaks on `zsh` shells. The link proposes a fix and it is implemented in this PR. I tested both `zsh` and `bash` and it seems to work.