### PR TITLE
Fix ascicgpu nvcc-wrapper bug with externals

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -36,6 +36,7 @@ class NaluWind(bNaluWind, ROCmPackage):
         if '+cuda' in self.spec:
             env.set("CUDA_LAUNCH_BLOCKING", "1")
             env.set("CUDA_MANAGED_FORCE_DEVICE_ALLOC", "1")
+            env.set('MPICH_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Force nalu-wind to set the `MPICH_CXX` flag to kokkos' c++ compiler.  Copies Trilinos' behavior.
This will enable STK developers to use externals again on ascicgpu

Closes #209 