### PR TITLE
Add nvcc-wrapper in nalu-wind to OpenMPI and MPT

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -36,7 +36,9 @@ class NaluWind(bNaluWind, ROCmPackage):
         if '+cuda' in self.spec:
             env.set("CUDA_LAUNCH_BLOCKING", "1")
             env.set("CUDA_MANAGED_FORCE_DEVICE_ALLOC", "1")
+            env.set('OMPI_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set('MPICH_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+            env.set('MPICXX_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Let's treat all the MPIs the same in `nalu-wind`: https://github.com/psakievich/spack-manager/pull/229