### PR TITLE
Strip dev_path from externals specs

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -95,11 +95,21 @@ def write_spec(view, spec):
       prefix: {prefix}
     buildable: false\n"""
 
+    pruned_spec = _spec_string_minus_dev_path(spec)
+
     return template.format(
         name=spec.name,
-        short_spec=spec.format(
-            '{name}{@version}{%compiler}{variants}{arch=architecture}'),
+        short_spec=pruned_spec,
         prefix=view.get_projection_for_spec(spec))
+
+
+def _spec_string_minus_dev_path(spec):
+    full_spec = spec.format(
+        '{name}{@version}{%compiler}{variants}{arch=architecture}')
+    spec_components = full_spec.split(' ')
+    pruned_componets = [x for x in spec_components if 'dev_path=' not in x]
+    pruned_spec = ' '.join(pruned_componets)
+    return pruned_spec
 
 
 def create_external_yaml_from_env(path, view_key, black_list, white_list):

--- a/spack-scripting/tests/test_external.py
+++ b/spack-scripting/tests/test_external.py
@@ -9,9 +9,24 @@ import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
 from spack.environment import config_dict
+from spack.spec import Spec
 
 env = spack.main.SpackCommand('env')
 manager = spack.main.SpackCommand('manager')
+
+
+@pytest.mark.parametrize('spec_str',
+                         ['amr-wind@main dev_path=/amr-wind',
+                          'nalu-wind@master+cuda cuda_arch=70 '
+                          'dev_path=/nalu-wind',
+                          'exawind@master dev_path=/exawind '
+                          '^nalu-wind@master dev_path=/nalu-wind'
+                          ' ^amr-wind@main dev_path=/amr-wind'])
+def test_stripDevPathFromExternals(spec_str):
+    assert 'dev_path' in spec_str
+    s = Spec(spec_str)
+    pruned_string = manager_cmds.external._spec_string_minus_dev_path(s)
+    assert 'dev_path' not in pruned_string
 
 
 def test_mustHaveActiveEnvironment(tmpdir):


### PR DESCRIPTION
Removing `dev_path=*` from entries in `externals.yaml` speeds up performance with externals.