### PR TITLE
Consolidate externals and multiple views

### DIFF
--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -328,9 +328,9 @@ def create_snapshots(args):
         os.environ['SPACK_MANAGER'], 'environments', extension)
 
     print('\nCreating snapshot environment')
-    
+
     command(manager, 'create-env', '-d', env_path)
-    
+
     e = ev.Environment(env_path)
 
     with e.write_transaction():

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -143,15 +143,11 @@ def view_excludes(snap_spec):
     return snap_spec.exclusions.copy()
 
 
-def add_spec(env, extension, data, link_type, create_modules):
-    ev.activate(env)
-    add(data.spec)
-    ev.deactivate()
-    excludes = view_excludes(data)
+def add_view(env, extension, link_type):
     view_path = os.path.join(
-        os.environ['SPACK_MANAGER'], 'views', extension, data.id)
-    view_dict = {data.id: {
-        'root': view_path, 'exclude': excludes,
+        os.environ['SPACK_MANAGER'], 'views', extension, 'snapshot')
+    view_dict = {'snapshot': {
+        'root': view_path,
         'projections': {'all': '{compiler.name}-{compiler.version}/{name}/'
                         '{version}',
                         '^cuda': '{compiler.name}-{compiler.version}-'
@@ -168,6 +164,19 @@ def add_spec(env, extension, data, link_type, create_modules):
         yaml['spack']['view'].update(view_dict)
     except AttributeError:
         yaml['spack']['view'] = view_dict
+
+    with open(env.manifest_path, 'w') as f:
+        syaml.dump(yaml, stream=f, default_flow_style=False)
+
+
+def add_spec(env, extension, data, create_modules):
+    ev.activate(env)
+    add(data.spec)
+    ev.deactivate()
+    excludes = view_excludes(data)
+
+    with open(env.manifest_path, 'r') as f:
+        yaml = syaml.load(f)
 
     if create_modules:
         module_excludes = excludes.copy()
@@ -319,16 +328,19 @@ def create_snapshots(args):
         os.environ['SPACK_MANAGER'], 'environments', extension)
 
     print('\nCreating snapshot environment')
+    
     command(manager, 'create-env', '-d', env_path)
+    
     e = ev.Environment(env_path)
+
     with e.write_transaction():
         e.yaml['spack']['concretization'] = 'separately'
         e.write()
 
     spec_data = machine_specs[machine]
-
+    add_view(e, extension, args.link_type)
     for s in spec_data:
-        add_spec(e, extension, s, args.link_type, args.modules)
+        add_spec(e, extension, s, args.modules)
 
     top_specs = get_top_level_specs(e)
 

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -105,10 +105,10 @@ def write_spec(env, spec):
         # ideally we could pull the install path off the spec
         # but I haven't figured out if that is possible
         print('WARNING: The following spec exists in the externals environment'
-        ' but is not captured in a view.'
-        ' It will be omitted from your available externals\n - %s' % pruned_spec)
+              ' but is not captured in a view.'
+              ' It will be omitted from your available externals\n - %s' % pruned_spec)
         return
-    
+
     return template.format(
         name=spec.name,
         short_spec=pruned_spec,
@@ -152,6 +152,7 @@ def create_external_yaml_from_env(env, black_list, white_list):
 
     return syaml.load_config(data)
 
+
 def _get_first_view_containing_spec(env, spec):
     for view in env.views.values():
         if view.__contains__(spec):
@@ -170,7 +171,6 @@ def external(parser, args):
         def print_snapshots(snaps):
             for s in snaps:
                 env_dir = os.path.join(extern_dir, s)
-                env = ev.Environment(env_dir)
                 print(' - {path}'.format(path=env_dir))
 
         print('-' * 54)
@@ -213,14 +213,12 @@ def external(parser, args):
 
     if not snap_env.views:
         tty.die('Environments used to create externals must have at least 1'
-        ' associated view')
+                ' associated view')
     # copy the file and overwrite any that may exist (or merge?)
     inc_name_abs = os.path.abspath(os.path.join(env.path, args.name))
 
     try:
-        src = create_external_yaml_from_env(
-                snap_env, args.blacklist, args.whitelist)
-            
+        src = create_external_yaml_from_env(snap_env, args.blacklist, args.whitelist)
     except ev.SpackEnvironmentError as e:
         tty.die(e.long_message)
 


### PR DESCRIPTION
Make it so all specs in the environment get added to the `externals.yaml`.

This makes it so we don't need to add any exclusions. We will still need them for modules.  

These changes are compatible with existing snapshots but will alter the view structure of new ones going forward.