### PR TITLE
Further work on externals and snapshots

### DIFF
--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -150,9 +150,9 @@ def add_view(env, extension, link_type):
         'root': view_path,
         'projections': {'all': '{compiler.name}-{compiler.version}/{name}/'
                         '{version}',
-                        '^cuda': '{compiler.name}-{compiler.version}-'
+                        '+cuda': '{compiler.name}-{compiler.version}-'
                         '{^cuda.name}-{^cuda.version}/{name}/{version}',
-                        '^rocm': '{compiler.name}-{compiler.version}-'
+                        '+rocm': '{compiler.name}-{compiler.version}-'
                         '{^rocm.name}-{^rocm.version}/{name}/{version}'},
         'link_type': link_type
     }}

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -150,9 +150,9 @@ def add_view(env, extension, link_type):
         'root': view_path,
         'projections': {'all': '{compiler.name}-{compiler.version}/{name}/'
                         '{version}',
-                        '+cuda': '{compiler.name}-{compiler.version}-'
+                        '^cuda': '{compiler.name}-{compiler.version}-'
                         '{^cuda.name}-{^cuda.version}/{name}/{version}',
-                        '+rocm': '{compiler.name}-{compiler.version}-'
+                        '^rocm': '{compiler.name}-{compiler.version}-'
                         '{^rocm.name}-{^rocm.version}/{name}/{version}'},
         'link_type': link_type
     }}

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -9,11 +9,11 @@ import llnl.util.tty as tty
 import spack
 import spack.config
 import spack.detection
-from spack.detection.common import _pkg_config_dict
 import spack.environment as ev
-from spack.spec import Spec
 import spack.util.spack_yaml as syaml
+from spack.detection.common import _pkg_config_dict
 from spack.environment import config_dict
+from spack.spec import Spec
 
 
 def get_external_dir():
@@ -105,9 +105,10 @@ def assemble_dict_of_detected_externals(env, black_list, white_list):
 
     def update_dictionary(env, spec):
         if spec.name in external_spec_dict:
-            external_spec_dict[spec.name].append(create_external_detected_spec(env, spec))
+            external_spec_dict[spec.name].append(
+                create_external_detected_spec(env, spec))
         else:
-            external_spec_dict[spec.name]=[create_external_detected_spec(env, spec)]
+            external_spec_dict[spec.name] = [create_external_detected_spec(env, spec)]
 
     for spec in env.all_specs():
         if black_list:
@@ -129,7 +130,7 @@ def create_yaml_from_detected_externals(ext_dict):
         config['buildable'] = False
         formatted_dict[name] = config
 
-    return syaml.syaml_dict({'packages':formatted_dict}) 
+    return syaml.syaml_dict({'packages': formatted_dict})
 
 
 def _spec_string_minus_dev_path(spec):
@@ -206,7 +207,8 @@ def external(parser, args):
     inc_name_abs = os.path.abspath(os.path.join(env.path, args.name))
 
     try:
-        detected = assemble_dict_of_detected_externals(snap_env, args.blacklist, args.whitelist)
+        detected = assemble_dict_of_detected_externals(
+            snap_env, args.blacklist, args.whitelist)
         src = create_yaml_from_detected_externals(detected)
     except ev.SpackEnvironmentError as e:
         tty.die(e.long_message)

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -128,7 +128,8 @@ def create_external_yaml_from_env(env, black_list, white_list):
     active_env = ev.active_environment()
     data = "packages:\n"
 
-    for s in env._get_environment_specs():
+    for s in env.all_specs():
+        print(s.name, s.full_hash())
         if black_list:
             if s.name in black_list:
                 continue


### PR DESCRIPTION
PR to fix some issues

- [ ]  Make projection path change if cuda/rocm is turned on rather than if it is just a dependency. Our cuda and non-cuda binaries were being assigned to the same directory in the projections (explains behavior on eagle) (Actually not sure if this is an issue. it is not on ascicgpu after all with the changes below)
- [x] Make all the specs get written properly to the `externals.yaml` file