### PR TITLE
Exawind package flaw

### DIFF
--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -48,7 +48,6 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('tioga+shared~nodegid')
     depends_on('yaml-cpp@0.6:')
     depends_on('nalu-wind+openfast', when='+openfast')
-    depends_on('amr-wind+openfast', when='+openfast')
     depends_on('openfast+cxx+shared@2.6.0', when='+openfast')
     depends_on('nalu-wind+hypre', when='+hypre')
     depends_on('amr-wind+hypre', when='+hypre')


### PR DESCRIPTION
The driver should never depend on amr-wind using openfast. at least not in the current scope of the software package