### PR TITLE
fix bug in ascic line in find_machine

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -44,7 +44,7 @@ machine_list = {
                        socket.gethostname()),
     'snl-hpc': MachineData(lambda: is_snl_hpc(socket.gethostname()),
                            socket.gethostname()),
-    'ascic': MachineData(lambda: 'ascic' in socket.gethostname(),
+    'ascic': MachineData(lambda: 'ascic' in socket.gethostname() and 'gpu' not in socket.gethostname(),
                          socket.gethostname()),
     'ascicgpu': MachineData(lambda: 'ascicgpu' in socket.gethostname(),
                             socket.gethostname()),

--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -44,7 +44,8 @@ machine_list = {
                        socket.gethostname()),
     'snl-hpc': MachineData(lambda: is_snl_hpc(socket.gethostname()),
                            socket.gethostname()),
-    'ascic': MachineData(lambda: 'ascic' in socket.gethostname() and 'gpu' not in socket.gethostname(),
+    'ascic': MachineData(lambda: 'ascic' in socket.gethostname()
+                            and 'gpu' not in socket.gethostname(),
                          socket.gethostname()),
     'ascicgpu': MachineData(lambda: 'ascicgpu' in socket.gethostname(),
                             socket.gethostname()),


### PR DESCRIPTION
thanks to @psakievich for pointing out that without this fix, ascicgpuXYZ would be picked up as "ascic", not "ascicgpu".