### PR TITLE
Add e4s config

### DIFF
--- a/configs/e4s/packages.yaml
+++ b/configs/e4s/packages.yaml
@@ -1,0 +1,6 @@
+packages:
+  all:
+    target: [x86_64]
+    compiler: [gcc, clang]
+    providers:
+      mpi: [mpich, openmpi]

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -68,6 +68,7 @@ class SnapshotSpec:
 machine_specs = {
     'darwin': [SnapshotSpec(exclusions=['%intel'])],
     'cee': [SnapshotSpec()],
+    'e4s': [SnapshotSpec()],
     'rhodes': [SnapshotSpec('gcc',
                             base_spec + '%gcc', ['%clang', '%intel']),
                SnapshotSpec('clang',

--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -10,7 +10,7 @@ class MachineData:
 
 
 def is_cee(hostname):
-    known_hosts = ('cee', 'ews', 'ecs', 'hpws')
+    known_hosts = ('cee', 'ews', 'ecw', 'ecs', 'hpws')
     for k in known_hosts:
         if k in hostname:
             return True
@@ -31,6 +31,13 @@ def is_jlse(hostname):
         if k in hostname:
             return True
     return False
+
+
+def is_e4s():
+    if 'E4S_MACHINE' in os.environ:
+        return True
+    else:
+        return False
 
 
 """
@@ -64,6 +71,8 @@ machine_list = {
     # JLSE
     'arcticus': MachineData(lambda: is_jlse(socket.gethostname()),
                             'arcticus.alcf.anl.gov'),
+    # E4S
+    'e4s': MachineData(lambda: is_e4s(), 'e4s.nodomain.gov'),
     # General
     'darwin': MachineData(lambda: sys.platform == 'darwin',
                           'darwin.nodomain.gov'),


### PR DESCRIPTION
Set up infrastructure to allow for e4s builds

@eugeneswalker this should allow you to setup a docker container with the entire exawind stack.

The process for setting up and building would look like this:

```console
# define a check for the config
export E4S_MACHINE=1
# clone spack-manager and activate it
git clone --recursive https://github.com/psakievich/spack-manager
export SPACK_MANAGER=$(pwd)/spack-manager
source $SPACK_MANAGER/start.sh
spack-start
# build the stack in an environment
create-exawind-snapshot.sh
```
