### PR TITLE
Add more CPU-only testing lines at SNL, remove the massive tolerances

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -4,4 +4,8 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast abs_tol=1e100 rel_tol=1e100 %gcc@9.3.0'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0 extra_name=-gcc@9.3.0+tioga+hypre+openfast'
+    - 'nalu-wind-nightly %gcc@9.3.0 extra_name=-gcc@9.3.0'
+    - 'nalu-wind-nightly %gcc@9.3.0 buildType=Debug extra_name=-gcc@9.3.0-Debug'
+    - 'nalu-wind-nightly %intel@20.0.2 extra_name=-intel@20.0.2'
+    - 'nalu-wind-nightly %clang@10.0.0 extra_name=-clang@10.0.0'


### PR DESCRIPTION
Removing the tolerances because the current gold file strategy is to create initial gold files from a run on this machine, so these unvetted gold files already match anyway.

@jrood-nrel maybe we can talk about the best way to handle the extra name.  On STK, we wanted test lines that didn't have all the extra packages, and we wanted at least one debug-mode build, but these use cases aren't currently supported by the auto-generated extra name in `nalu-wind-nightly/package.py`.  For now I just hard-coded some, but maybe there's a way to do this more cleanly in the package.py.