### PR TITLE
Remove massive gold file tolerances from SNL machines

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -4,4 +4,4 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast abs_tol=1e100 rel_tol=1e100 %gcc@9.3.0'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -4,4 +4,4 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda cuda_arch=70 abs_tol=1e100 rel_tol=1e100 %gcc@9.3.0'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0'


### PR DESCRIPTION
The current gold file strategy is to create initial gold files from a run on the current machine, so these unvetted gold files already match anyway.