### PR TITLE
e4s config: packages: prefer gcc@9.4.0

### DIFF
--- a/configs/e4s/packages.yaml
+++ b/configs/e4s/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
     target: [x86_64]
-    compiler: [gcc, clang]
+    compiler: [gcc@9.4.0, clang]
     providers:
       mpi: [mpich, openmpi]


### PR DESCRIPTION
Our runner image `ecpe4s/ubuntu20.04-runner-x86_64:2022-05-01` has both `GCC 9.4.0` and `GCC 11.1.0` -- we would like to use `%gcc@9.4.0` by default if that is OK with ExaWind team.

@psakievich @jrood-nrel 