### PR TITLE
Updates to Sandia nightly testing

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -4,4 +4,6 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0 build_type=Debug'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -4,4 +4,9 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos~uvm'

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -30,6 +30,9 @@ class NaluWindNightly(bNaluWind, CudaPackage):
     variant('host_name', default='default')
     variant('extra_name', default='default')
 
+    variant('snl', default=False, description='Reports to SNL dashboard')
+    patch('snl_ctest.patch', when='+snl')
+
     phases = ['test']
 
     def ctest_args(self):
@@ -78,10 +81,6 @@ class NaluWindNightly(bNaluWind, CudaPackage):
         ctest_options.append('-VV')
         ctest_options.append('-S')
         ctest_options.append(os.path.join(self.stage.source_path,'reg_tests','CTestNightlyScript.cmake'))
-        if 'ascic' in machine:
-            ctest_options.append(define('CTEST_DROP_METHOD', 'https'))
-            ctest_options.append(define('CTEST_DROP_SITE', 'sierra-cdash.sandia.gov'))
-            ctest_options.append(define('CTEST_NIGHTLY_START_TIME', '18:00:00 MDT'))
 
         return ctest_options
 

--- a/repos/exawind/packages/nalu-wind-nightly/snl_ctest.patch
+++ b/repos/exawind/packages/nalu-wind-nightly/snl_ctest.patch
@@ -1,0 +1,17 @@
+diff --git a/CTestConfig.cmake b/CTestConfig.cmake
+index 9cbdbbb5..fc78ce2b 100644
+--- a/CTestConfig.cmake
++++ b/CTestConfig.cmake
+@@ -7,9 +7,9 @@
+ ##   INCLUDE(CTest)
+ 
+ set(CTEST_PROJECT_NAME "Nalu-Wind")
+-set(CTEST_NIGHTLY_START_TIME "00:00:00 EDT")
++set(CTEST_NIGHTLY_START_TIME "18:00:00 MDT")
+ 
+-set(CTEST_DROP_METHOD "http")
+-set(CTEST_DROP_SITE "my.cdash.org")
++set(CTEST_DROP_METHOD "https")
++set(CTEST_DROP_SITE "sierra-cdash.sandia.gov")
+ set(CTEST_DROP_LOCATION "/submit.php?project=Nalu-Wind")
+ set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
It seems that CTest doesn't allow us to override options specified in the cmake script.  So we need to patch the repo instead in order to report to the Sandia dashboard.  Reporting to this dashboard allows us to leverage existing infrastructure to avoid the issues with paid CDash plans.

This PR also adds multiple testing lines for Sandia platforms.