### PR TITLE
Change SNL test names so they're distinct on the dashboard

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -4,6 +4,6 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0'
-    - 'nalu-wind-nightly+snl %gcc@9.3.0'
-    - 'nalu-wind-nightly+snl %gcc@9.3.0 build_type=Debug'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 dashboard_name="-release+fftw+tioga+hypre+openfast"'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0 dashboard_name="-release"'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0 build_type=Debug dashboard_name="-debug"'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -4,9 +4,9 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm dashboard_name="-release+uvm+fftw+tioga+hypre+openfast"'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm dashboard_name="-release+uvm"'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos+uvm dashboard_name="-debug+uvm"'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm dashboard_name="-release~uvm+fftw+tioga+hypre+openfast"'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm dashboard_name="-release~uvm"'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos~uvm dashboard_name="-debug~uvm"'

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -29,6 +29,7 @@ class NaluWindNightly(bNaluWind, CudaPackage):
 
     variant('host_name', default='default')
     variant('extra_name', default='default')
+    variant('dashboard_name', default='default')
 
     variant('snl', default=False, description='Reports to SNL dashboard')
     patch('snl_ctest.patch', when='+snl')
@@ -54,6 +55,13 @@ class NaluWindNightly(bNaluWind, CudaPackage):
             spec.variants['extra_name'].value = spec.variants['extra_name'].value + '-trilinos@' + str(spec['trilinos'].version)
             if '+cuda' in spec:
                 spec.variants['extra_name'].value = spec.variants['extra_name'].value + '-cuda@' + str(spec['cuda'].version)
+
+        if spec.variants['dashboard_name'].value != 'default':
+            spec.variants['extra_name'].value = spec.format('-{compiler}')
+            if '+cuda' in spec:
+                spec.variants['extra_name'].value = spec.variants['extra_name'].value + '-cuda@' + str(spec['cuda'].version)
+            spec.variants['extra_name'].value = spec.variants['extra_name'].value + spec.variants['dashboard_name'].value
+
 
         # Cmake options for ctest
         cmake_options = self.std_cmake_args


### PR DESCRIPTION
All the lines were getting combined, because the "extra_name" wasn't distinct.  This adds a new option, "dashboard_name" to provide uniqueness between builds with different variants.

The main reason for the new variant is that I wanted the compilers to still be automatically picked up into the extra_name that would be passed to ctest.  I'm open to suggestions on approaches with less code duplication -- I couldn't think of a better way of doing it to provide unique names for the SNL tests that automatically set the compiler and cuda version, while not changing the name format for the NREL tests.