### PR TITLE
Refactor extra-name creation and clean up duplication

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -4,6 +4,6 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 dashboard_name="-release+fftw+tioga+hypre+openfast"'
-    - 'nalu-wind-nightly+snl %gcc@9.3.0 dashboard_name="-release"'
-    - 'nalu-wind-nightly+snl %gcc@9.3.0 build_type=Debug dashboard_name="-debug"'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0'
+    - 'nalu-wind-nightly+snl %gcc@9.3.0 build_type=Debug'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -4,9 +4,9 @@ spack:
   concretization: separately
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 dashboard_name="-release+uvm+fftw+tioga+hypre+openfast" ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 dashboard_name="-release+uvm" ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug dashboard_name="-debug+uvm" ^trilinos+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 dashboard_name="-release~uvm+fftw+tioga+hypre+openfast" ^trilinos~uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 dashboard_name="-release~uvm" ^trilinos~uvm'
-    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug dashboard_name="-debug~uvm" ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 ^trilinos~uvm'
+    - 'nalu-wind-nightly+snl +cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos~uvm'

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -27,8 +27,8 @@ class NaluWindNightly(bNaluWind, CudaPackage):
 
     version('master', branch='master', submodules=True)
 
-    variant('host_name', default=None)
-    variant('extra_name', default=None)
+    variant('host_name', default='default')
+    variant('extra_name', default='default')
 
     variant('snl', default=False, description='Reports to SNL dashboard')
     patch('snl_ctest.patch', when='+snl')
@@ -40,13 +40,13 @@ class NaluWindNightly(bNaluWind, CudaPackage):
         define = CMakePackage.define
         machine = find_machine(verbose=False, full_machine_name=True)
 
-        if spec.variants['host_name'].value is None:
+        if spec.variants['host_name'].value == 'default':
             if machine == 'NOT-FOUND':
                 spec.variants['host_name'].value = spec.format('{architecture}')
             else:
                 spec.variants['host_name'].value = machine
 
-        if spec.variants['extra_name'].value is None:
+        if spec.variants['extra_name'].value == 'default':
             compilers = spec.format('{compiler}')
             trilinos = 'trilinos@' + str(spec['trilinos'].version)
 

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -53,15 +53,15 @@ class NaluWindNightly(bNaluWind, CudaPackage):
             if '+cuda' in spec:
                 compilers += '-cuda@' + str(spec['cuda'].version)
                 if '+uvm' in spec['trilinos']:
-                    trilinos += '+uvm'
+                    trilinos = trilinos + '+uvm'
                 else:
-                    trilinos += '~uvm'
+                    trilinos = trilinos + '~uvm'
 
             extra_name = '-' + compilers
             if '+snl' in spec:
                 variants = variant_peeler(spec.format('{variants}')
-                extra_name += ' ' + variants
-            extra_name += ' ^' + trilinos
+                extra_name = extra_name + ' ' + variants
+            extra_name = extra_name + ' ^' + trilinos
             spec.variants['extra_name'].value = extra_name
 
         # Cmake options for ctest

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -59,7 +59,7 @@ class NaluWindNightly(bNaluWind, CudaPackage):
 
             extra_name = '-' + compilers
             if '+snl' in spec:
-                variants = variant_peeler(spec.format('{variants}')
+                variants = variant_peeler(spec.format('{variants}'))
                 extra_name = extra_name + '-' + variants
             extra_name = extra_name + '^' + trilinos
             spec.variants['extra_name'].value = extra_name

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -57,11 +57,12 @@ class NaluWindNightly(bNaluWind, CudaPackage):
                 else:
                     trilinos += '~uvm'
 
-            spec.variants['extra_name'].value  = '-' + compilers
+            extra_name = '-' + compilers
             if '+snl' in spec:
                 variants = variant_peeler(spec.format('{variants}')
-                spec.variants['extra_name'].value += ' ' + variants
-            spec.variants['extra_name'].value += ' ^' + trilinos
+                extra_name += ' ' + variants
+            extra_name += ' ^' + trilinos
+            spec.variants['extra_name'].value = extra_name
 
         # Cmake options for ctest
         cmake_options = self.std_cmake_args

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -17,7 +17,7 @@ def variant_peeler(var_str):
         output+='+{v}'.format(v=var_str[match.start(): match.end()])
     # extract build type
     for match in re.finditer('r(?<=build_type=)(a-zA-Z)', var_str):
-        output = var_str[match.start():match.end()] + ' ' + output
+        output = var_str[match.start():match.end()] + output
     return output
 
 
@@ -60,8 +60,8 @@ class NaluWindNightly(bNaluWind, CudaPackage):
             extra_name = '-' + compilers
             if '+snl' in spec:
                 variants = variant_peeler(spec.format('{variants}')
-                extra_name = extra_name + ' ' + variants
-            extra_name = extra_name + ' ^' + trilinos
+                extra_name = extra_name + '-' + variants
+            extra_name = extra_name + '^' + trilinos
             spec.variants['extra_name'].value = extra_name
 
         # Cmake options for ctest


### PR DESCRIPTION
* Cleans up some duplication introduced by the "dashboard_name" parameter
* Makes it so variants are added to the "extra_name" automatically, only for SNL dashboard builds
* ~~Switch from using "default" as the default value for "host_name" and "extra_name" to the None singleton~~ (can't do this cause it makes Spack mad)
* Slight rearrangement so that the cuda version is listed with the compiler version, and the trilinos version comes last (reflecting standard spack spec arrangement)
* For Cuda builds, always give the Trilinos UVM setting as part of the build name