### PR TITLE
Add framework for testing nalu-wind-nightly package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .cache
 Configuring
 .tmp/
+*.swp

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,4 +4,4 @@
 export SPACK_MANAGER=$(pwd)
 source ${SPACK_MANAGER}/start.sh
 spack-start
-spack unit-test --extension scripting
+spack -C ${SPACK_MANAGER}/configs/base unit-test --extension scripting

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,4 +4,4 @@
 export SPACK_MANAGER=$(pwd)
 source ${SPACK_MANAGER}/start.sh
 spack-start
-spack -C ${SPACK_MANAGER}/configs/base unit-test --extension scripting
+spack unit-test --extension scripting

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -7,3 +7,7 @@ from spack.test.conftest import *  # noqa: F401
 @pytest.fixture(scope='session')
 def exawind_repo_path():
     yield os.path.join(os.environ['SPACK_MANAGER'], 'repos', 'exawind')
+
+@pytest.fixture(scope='session')
+def builtin_repo_path():
+    yield os.path.join(os.environ['SPACK_MANAGER'], 'spack', 'var', 'spack', 'repos', 'builtin')

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -7,6 +7,7 @@
 
 
 import os
+
 import pytest
 
 import spack.paths
@@ -19,20 +20,20 @@ from spack.test.conftest import *  # noqa: F401
 def builtin_repo_path():
     yield spack.paths.packages_path
 
+
 @pytest.fixture(scope='session')
 def exawind_repo_path():
     yield os.path.join(os.environ['SPACK_MANAGER'], 'repos', 'exawind')
+
 
 @pytest.fixture(scope='session')
 def create_package(builtin_repo_path, exawind_repo_path):
     packages = {}
 
-
     def _create(spec):
         if spec not in packages:
             packages[spec] = _create_new(spec)
         return packages[spec]
-
 
     def _create_new(spec):
         with spack.repo.use_repositories(builtin_repo_path, exawind_repo_path):

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -14,21 +14,17 @@ def builtin_repo_path():
 def exawind_repo_path():
     yield os.path.join(os.environ['SPACK_MANAGER'], 'repos', 'exawind')
 
+@pytest.fixture(scope='session')
+def create_package(builtin_repo_path, exawind_repo_path):
+    packages = {}
 
-class PackageMap:
-    def __init__(self, *paths):
-        self.paths = paths
-        self.packages = {}
+    def _create(spec):
+        if spec not in packages:
+            packages[spec] = _create_new(spec)
+        return packages[spec]
 
-    def create(self, spec):
-        if spec not in self.packages:
-            self.packages[spec] = self._create_new(spec)
-        return self.packages[spec]
-
-    def _create_new(self, spec):
-        with spack.repo.use_repositories(*self.paths):
+    def _create_new(spec):
+        with spack.repo.use_repositories(builtin_repo_path, exawind_repo_path):
             return Spec(spec).package
 
-@pytest.fixture(scope='session')
-def packages(builtin_repo_path, exawind_repo_path):
-    return PackageMap(builtin_repo_path, exawind_repo_path)
+    return _create

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -1,1 +1,9 @@
+import os
+import pytest
+
 from spack.test.conftest import *  # noqa: F401
+
+
+@pytest.fixture(scope='session')
+def exawind_repo_path():
+    yield os.path.join(os.environ['SPACK_MANAGER'], 'repos', 'exawind')

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -5,11 +5,12 @@
 # This software is released under the BSD 3-clause license. See LICENSE file
 # for more details.
 
+
 import os
 import pytest
 
-import spack.repo
 import spack.paths
+import spack.repo
 from spack.spec import Spec
 from spack.test.conftest import *  # noqa: F401
 
@@ -26,10 +27,12 @@ def exawind_repo_path():
 def create_package(builtin_repo_path, exawind_repo_path):
     packages = {}
 
+
     def _create(spec):
         if spec not in packages:
             packages[spec] = _create_new(spec)
         return packages[spec]
+
 
     def _create_new(spec):
         with spack.repo.use_repositories(builtin_repo_path, exawind_repo_path):

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -1,13 +1,25 @@
 import os
 import pytest
 
+import spack.repo
+from spack.spec import Spec
 from spack.test.conftest import *  # noqa: F401
 
+
+@pytest.fixture(scope='session')
+def builtin_repo_path():
+    yield os.path.join(os.environ['SPACK_MANAGER'], 'spack', 'var', 'spack', 'repos', 'builtin')
 
 @pytest.fixture(scope='session')
 def exawind_repo_path():
     yield os.path.join(os.environ['SPACK_MANAGER'], 'repos', 'exawind')
 
 @pytest.fixture(scope='session')
-def builtin_repo_path():
-    yield os.path.join(os.environ['SPACK_MANAGER'], 'spack', 'var', 'spack', 'repos', 'builtin')
+def create_package(builtin_repo_path, exawind_repo_path):
+    def create(spec):
+        with spack.repo.use_repositories(exawind_repo_path, builtin_repo_path) as exawind_repo:
+            spec = Spec('nalu-wind-nightly')
+            spec.concretize()
+            return spec.package
+
+    return create

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -27,9 +27,7 @@ class PackageMap:
 
     def _create_new(self, spec):
         with spack.repo.use_repositories(*self.paths):
-            spec_obj = Spec(spec)
-            spec_obj.concretize()
-            return spec_obj.package
+            return Spec(spec).package
 
 @pytest.fixture(scope='session')
 def packages(builtin_repo_path, exawind_repo_path):

--- a/spack-scripting/tests/conftest.py
+++ b/spack-scripting/tests/conftest.py
@@ -2,13 +2,14 @@ import os
 import pytest
 
 import spack.repo
+import spack.paths
 from spack.spec import Spec
 from spack.test.conftest import *  # noqa: F401
 
 
 @pytest.fixture(scope='session')
 def builtin_repo_path():
-    yield os.path.join(os.environ['SPACK_MANAGER'], 'spack', 'var', 'spack', 'repos', 'builtin')
+    yield spack.paths.packages_path
 
 @pytest.fixture(scope='session')
 def exawind_repo_path():

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -2,14 +2,14 @@ import os
 import pytest
 
 
-def test_package_name(packages):
-    package = packages.create('nalu-wind-nightly')
+def test_package_name(create_package):
+    package = create_package('nalu-wind-nightly')
     assert package.name == 'nalu-wind-nightly'
 
-def test_package_picks_up_variants(packages):
-    package = packages.create('nalu-wind-nightly+snl')
+def test_package_picks_up_variants(create_package):
+    package = create_package('nalu-wind-nightly+snl')
     assert package.spec.variants['snl'].value
 
-def test_package_picks_up_default_variants(packages):
-    package = packages.create('nalu-wind-nightly')
+def test_package_picks_up_default_variants(create_package):
+    package = create_package('nalu-wind-nightly')
     assert 'snl' not in package.spec.variants

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -5,10 +5,12 @@ import spack.repo
 from spack.spec import Spec
 
 
-def test_can_read_exawind_repo(exawind_repo_path):
+def test_can_read_exawind_repo(exawind_repo_path, builtin_repo_path):
     assert os.path.isdir(exawind_repo_path)
-    with spack.repo.use_repositories(exawind_repo_path) as exawind_repo:
-        concrete_spec = Spec('nalu-wind-nightly').concretize()
+    assert os.path.isdir(builtin_repo_path)
+    with spack.repo.use_repositories(exawind_repo_path, builtin_repo_path) as exawind_repo:
+        abstract_spec = Spec('nalu-wind-nightly')
+        concrete_spec = abstract_spec.concretize()
         assert concrete_spec.variants('extra_name')
         package = concrete_spec.package
         package.ctest_args()

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -9,9 +9,9 @@ def test_can_read_exawind_repo(exawind_repo_path, builtin_repo_path):
     assert os.path.isdir(exawind_repo_path)
     assert os.path.isdir(builtin_repo_path)
     with spack.repo.use_repositories(exawind_repo_path, builtin_repo_path) as exawind_repo:
-        abstract_spec = Spec('nalu-wind-nightly')
-        concrete_spec = abstract_spec.concretize()
-        assert concrete_spec.variants('extra_name')
-        package = concrete_spec.package
-        package.ctest_args()
-        assert package.spec.variants['extra_name'] != 'default'
+        spec = Spec('nalu-wind-nightly')
+        spec.concretize()
+        assert spec.variants['extra_name'].value == 'default'
+        package = spec.package
+        #package.ctest_args()  # test chokes on setting CMAKE_CXX_COMPILER from mpi spec ...
+        assert package.spec.variants['extra_name'].value == 'default'

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,5 +1,4 @@
 import pytest
 import importlib
 
-nalu_wind_nightly = importlib.import_module('...repos.exawind.packages.nalu-wind-nightly.package', 'package')
-#from ...repos.exawind.packages.nalu-wind-nightly.package import *
+from spack.pkg.exawind.nalu_wind_nightly import NaluWindNighlty 

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,3 +1,9 @@
 import pytest
 
-from spack.pkg.exawind.nalu_wind_nightly import NaluWindNightly
+import spack.repo
+from spack.spec import Spec
+
+
+def test_can_read_exawind_repo(exawind_repo_path):
+    with spack.repo.use_repositories(exawind_repo_path) as exawind_repo:
+        spec = Spec('nalu-wind-nightly')

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -2,7 +2,14 @@ import os
 import pytest
 
 
-def test_can_read_exawind_repo(create_package):
-    package = create_package('nalu-wind-nightly')
-    #package.ctest_args()  # test chokes on setting CMAKE_CXX_COMPILER from mpi spec ...
-    assert package.spec.variants['extra_name'].value == 'default'
+def test_package_name(packages):
+    package = packages.create('nalu-wind-nightly')
+    assert package.name == 'nalu-wind-nightly'
+
+def test_package_picks_up_variants(packages):
+    package = packages.create('nalu-wind-nightly+snl')
+    assert package.spec.variants['snl'].value
+
+def test_package_picks_up_default_variants(packages):
+    package = packages.create('nalu-wind-nightly')
+    assert not package.spec.variants['snl'].value

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,4 +1,3 @@
 import pytest
-import importlib
 
-from spack.pkg.exawind.nalu_wind_nightly import NaluWindNighlty 
+from spack.pkg.exawind.nalu_wind_nightly import NaluWindNightly

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -12,4 +12,4 @@ def test_package_picks_up_variants(packages):
 
 def test_package_picks_up_default_variants(packages):
     package = packages.create('nalu-wind-nightly')
-    assert not package.spec.variants['snl'].value
+    assert 'snl' not in package.spec.variants

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -6,4 +6,4 @@ from spack.spec import Spec
 
 def test_can_read_exawind_repo(exawind_repo_path):
     with spack.repo.use_repositories(exawind_repo_path) as exawind_repo:
-        spec = Spec('nalu-wind-nightly')
+        concrete_spec = Spec('nalu-wind-nightly').concretize()

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,0 +1,5 @@
+import pytest
+import importlib
+
+nalu_wind_nightly = importlib.import_module('...repos.exawind.packages.nalu-wind-nightly.package', 'package')
+#from ...repos.exawind.packages.nalu-wind-nightly.package import *

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -10,3 +10,6 @@ def test_can_read_exawind_repo(exawind_repo_path):
     with spack.repo.use_repositories(exawind_repo_path) as exawind_repo:
         concrete_spec = Spec('nalu-wind-nightly').concretize()
         assert concrete_spec.variants('extra_name')
+        package = concrete_spec.package
+        package.ctest_args()
+        assert package.spec.variants['extra_name'] != 'default'

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import spack.repo
@@ -5,5 +6,7 @@ from spack.spec import Spec
 
 
 def test_can_read_exawind_repo(exawind_repo_path):
+    assert os.path.isdir(exawind_repo_path)
     with spack.repo.use_repositories(exawind_repo_path) as exawind_repo:
         concrete_spec = Spec('nalu-wind-nightly').concretize()
+        assert concrete_spec.variants('extra_name')

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,17 +1,8 @@
 import os
 import pytest
 
-import spack.repo
-from spack.spec import Spec
 
-
-def test_can_read_exawind_repo(exawind_repo_path, builtin_repo_path):
-    assert os.path.isdir(exawind_repo_path)
-    assert os.path.isdir(builtin_repo_path)
-    with spack.repo.use_repositories(exawind_repo_path, builtin_repo_path) as exawind_repo:
-        spec = Spec('nalu-wind-nightly')
-        spec.concretize()
-        assert spec.variants['extra_name'].value == 'default'
-        package = spec.package
-        #package.ctest_args()  # test chokes on setting CMAKE_CXX_COMPILER from mpi spec ...
-        assert package.spec.variants['extra_name'].value == 'default'
+def test_can_read_exawind_repo(create_package):
+    package = create_package('nalu-wind-nightly')
+    #package.ctest_args()  # test chokes on setting CMAKE_CXX_COMPILER from mpi spec ...
+    assert package.spec.variants['extra_name'].value == 'default'

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -1,14 +1,20 @@
-import os
-import pytest
+# Copyright (c) 2022, National Technology & Engineering Solutions of Sandia,
+# LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# This software is released under the BSD 3-clause license. See LICENSE file
+# for more details.
 
 
 def test_package_name(create_package):
     package = create_package('nalu-wind-nightly')
     assert package.name == 'nalu-wind-nightly'
 
+
 def test_package_picks_up_variants(create_package):
     package = create_package('nalu-wind-nightly+snl')
     assert package.spec.variants['snl'].value
+
 
 def test_package_picks_up_default_variants(create_package):
     package = create_package('nalu-wind-nightly')


### PR DESCRIPTION
* For now, we don't concretize the spec, in order to make the test predictable and robust -- i.e. we don't want to be checking for specific variants, and then fail later when someone makes another variant default.
  * Not concretizing has the added advantage of not slowing the tests down by several seconds per spec.
  * The fixture does memoize packages, so we only have to create one for each unique abstract spec if we do decide we really need concretization.
* Also, this adds *.swp to the .gitignore

First step towards resolving #280 