### PR TITLE
Update snl-hpc configuration

### DIFF
--- a/configs/snl-hpc/packages.yaml
+++ b/configs/snl-hpc/packages.yaml
@@ -4,12 +4,12 @@ packages:
       read: group
       group: wg-sierra-users
     compiler:
+    - gcc@7.2.0
     - intel@19.0.3.199
-    - gcc@8.3.1
     providers:
       mpi:
-      - mpich
       - openmpi
+      - mpich
       blas:
       - netlib-lapack
       lapack:
@@ -28,6 +28,11 @@ packages:
     variants: +mlx5-dv+optimizations
   openmpi:
     variants: ~vt+pmi schedulers=slurm fabrics=auto legacylaunchers=true 
+    buildable: false
+    externals:
+    - spec: openmpi@3.1.6 %gcc@7.2.0
+      modules:
+      - cde/prod/gcc/7.2.0/openmpi/3.1.6
   slurm:
     externals:
     - spec: slurm@20.02.6


### PR DESCRIPTION
I updated the `compile.yaml` and `packages.yaml` specifications for the `snl-hpc` machines.  I wasn't able to get intel compilers to work on the cluster, nor things to run with mpich.  However, I was able to use the gcc compilers and the prebuilt openmpi modules to get things to compile and run.   

These changes should allow things to work out of the box for skybridge/chama, using a spec like:  
```
spack manager create-env --name exawind_gcc -m snl-hpc --spec 'nalu-wind@master+openfast amr-wind@main+openfast %gcc@7.2.0'
```

Lawrence