### PR TITLE
change to whitelisting only the variants we want to see

### DIFF
--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -49,8 +49,8 @@ class NaluWindNightly(bNaluWind, CudaPackage):
         return self.spec[package].format('{name}{@version}')
 
     def dashboard_variants(self):
-        blacklist = ['build_type', 'snl', 'pic', 'cuda', 'cuda_arch', 'tests']
-        printable = [v for v in self.spec.variants if v not in blacklist]
+        whitelist = ['fftw', 'hypre', 'tioga', 'openfast']
+        printable = [v for v in self.spec.variants if v in whitelist]
         enabled = [v for v in printable if self.spec.variants[v].value]
 
         build_type = self.spec.format('{variants.build_type}').split('=')[1]

--- a/spack-scripting/tests/test_nalu_wind_nightly.py
+++ b/spack-scripting/tests/test_nalu_wind_nightly.py
@@ -137,35 +137,15 @@ def test_dashboard_variants_contains_enabled(create_package):
 
 def test_dashboard_variants_contains_multiple_enabled(create_package):
     package = create_package(
-        'nalu-wind-nightly+hypre+tioga+openfast build_type=Release')
-    assert package.dashboard_variants() == 'Release+hypre+tioga+openfast'
+        'nalu-wind-nightly+fftw+hypre+tioga+openfast build_type=Release')
+    assert package.dashboard_variants() == 'Release+fftw+hypre+tioga+openfast'
 
 
-def test_dashboard_variants_doesnt_contain_snl(create_package):
+def test_dashboard_variants_doesnt_contain_non_whitelisted(create_package):
     package = create_package(
-        'nalu-wind-nightly+hypre+tioga+openfast+snl build_type=Release')
-    assert package.dashboard_variants() == 'Release+hypre+tioga+openfast'
-
-
-def test_dashboard_variants_doesnt_contain_pic(create_package):
-    package = create_package('nalu-wind-nightly+pic+hypre+tioga build_type=Release')
-    assert package.dashboard_variants() == 'Release+hypre+tioga'
-
-
-def test_dashboard_variants_doesnt_contain_cuda(create_package):
-    package = create_package('nalu-wind-nightly+cuda+openfast build_type=Release')
-    assert package.dashboard_variants() == 'Release+openfast'
-
-
-def test_dashboard_variants_doesnt_contain_cuda_arch(create_package):
-    package = create_package(
-        'nalu-wind-nightly+cuda+openfast cuda_arch=70 build_type=Release')
-    assert package.dashboard_variants() == 'Release+openfast'
-
-
-def test_dashboard_variants_doesnt_contain_tests(create_package):
-    package = create_package('nalu-wind-nightly+tests build_type=Release')
-    assert package.dashboard_variants() == 'Release'
+        '''nalu-wind-nightly+fftw+hypre+tioga+openfast+snl+cuda
+        cuda_arch=70 abs_tol=1e-15 build_type=Release''')
+    assert package.dashboard_variants() == 'Release+fftw+hypre+tioga+openfast'
 
 
 def test_dashboard_variants_doesnt_contain_disabled(create_package):


### PR DESCRIPTION
The SNL dashboard was pretty unreadable, because the extra_name picked up all variants that we didn't explicitly blacklist.  Changed to explicitly whitelisting the ones we want to see, so that we're more robust to future changes in the package.