### PR TITLE
Update SNL configs to utilize CDE spack work

### DIFF
--- a/configs/ascic/compilers.yaml
+++ b/configs/ascic/compilers.yaml
@@ -15,13 +15,75 @@ compilers:
 - compiler:
     environment: {}
     extra_rpaths:
-    - /opt/rh/devtoolset-8/root/usr/lib64
-    modules: []
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib64
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/libexec
     flags: {}
+    modules: []
     operating_system: rhel7
     paths:
-      cc: /opt/rh/devtoolset-8/root/usr/bin/gcc
-      cxx: /opt/rh/devtoolset-8/root/usr/bin/g++
-      f77: /opt/rh/devtoolset-8/root/usr/bin/gfortran
-      fc: /opt/rh/devtoolset-8/root/usr/bin/gfortran
-    spec: gcc@8.3.1
+      cc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gcc
+      cxx: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/g++
+      f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
+      fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
+    spec: gcc@7.2.0
+    target: x86_64
+- compiler:
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+        -O2
+      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
+        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
+        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/configs/ascic/compilers.yaml
+++ b/configs/ascic/compilers.yaml
@@ -13,6 +13,20 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@8.3.1
+    environment: {}
+    extra_rpaths:
+    - /opt/rh/devtoolset-8/root/usr/lib64
+    modules: []
+    flags: {}
+    operating_system: rhel7
+    paths:
+      cc: /opt/rh/devtoolset-8/root/usr/bin/gcc
+      cxx: /opt/rh/devtoolset-8/root/usr/bin/g++
+      f77: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+      fc: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+- compiler:
+    spec: gcc@7.2.0
     environment: {}
     extra_rpaths:
     - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib64
@@ -26,7 +40,6 @@ compilers:
       cxx: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/g++
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
-    spec: gcc@7.2.0
     target: x86_64
 - compiler:
     spec: gcc@10.3.0

--- a/configs/ascic/compilers.yaml
+++ b/configs/ascic/compilers.yaml
@@ -1,5 +1,62 @@
 compilers:
 - compiler:
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxxflags: -gxx-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      fflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+        C_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CPLUS_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        INCLUDE: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CMAKE_PREFIX_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+      set:
+        I_MPI_CC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@9.3.0
     paths:
       cc: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gcc
@@ -41,62 +98,4 @@ compilers:
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
     target: x86_64
-- compiler:
-    spec: gcc@10.3.0
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      set:
-        http_proxy: http://proxy.sandia.gov:80/
-        https_proxy: http://proxy.sandia.gov:80/
-    extra_rpaths: []
-- compiler:
-    spec: intel@2021.1.2
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    flags:
-      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-        -O2
-      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      prepend_path:
-        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
-        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
-        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    extra_rpaths: []
-- compiler:
-    spec: clang@12.0.1
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
     extra_rpaths: []

--- a/configs/ascic/upstreams.yaml
+++ b/configs/ascic/upstreams.yaml
@@ -1,0 +1,3 @@
+upstreams:
+  cde-v3:
+    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack

--- a/configs/ascic/upstreams.yaml
+++ b/configs/ascic/upstreams.yaml
@@ -1,3 +1,3 @@
 upstreams:
   cde-v3:
-    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack
+    install_tree: /projects/cde/v3/cee/spack/opt/spack/

--- a/configs/ascicgpu/compilers.yaml
+++ b/configs/ascicgpu/compilers.yaml
@@ -15,13 +15,75 @@ compilers:
 - compiler:
     environment: {}
     extra_rpaths:
-    - /opt/rh/devtoolset-8/root/usr/lib64
-    modules: []
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib64
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib
+    - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/libexec
     flags: {}
+    modules: []
     operating_system: rhel7
     paths:
-      cc: /opt/rh/devtoolset-8/root/usr/bin/gcc
-      cxx: /opt/rh/devtoolset-8/root/usr/bin/g++
-      f77: /opt/rh/devtoolset-8/root/usr/bin/gfortran
-      fc: /opt/rh/devtoolset-8/root/usr/bin/gfortran
-    spec: gcc@8.3.1
+      cc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gcc
+      cxx: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/g++
+      f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
+      fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
+    spec: gcc@7.2.0
+    target: x86_64
+- compiler:
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+        -O2
+      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
+        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
+        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/configs/ascicgpu/compilers.yaml
+++ b/configs/ascicgpu/compilers.yaml
@@ -13,6 +13,20 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@8.3.1
+    environment: {}
+    extra_rpaths:
+    - /opt/rh/devtoolset-8/root/usr/lib64
+    modules: []
+    flags: {}
+    operating_system: rhel7
+    paths:
+      cc: /opt/rh/devtoolset-8/root/usr/bin/gcc
+      cxx: /opt/rh/devtoolset-8/root/usr/bin/g++
+      f77: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+      fc: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+- compiler:
+    spec: gcc@7.2.0
     environment: {}
     extra_rpaths:
     - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib64
@@ -26,7 +40,6 @@ compilers:
       cxx: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/g++
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
-    spec: gcc@7.2.0
     target: x86_64
 - compiler:
     spec: gcc@10.3.0

--- a/configs/ascicgpu/compilers.yaml
+++ b/configs/ascicgpu/compilers.yaml
@@ -1,5 +1,62 @@
 compilers:
 - compiler:
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxxflags: -gxx-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      fflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+        C_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CPLUS_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        INCLUDE: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CMAKE_PREFIX_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+      set:
+        I_MPI_CC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@9.3.0
     paths:
       cc: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gcc
@@ -41,62 +98,4 @@ compilers:
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
     target: x86_64
-- compiler:
-    spec: gcc@10.3.0
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      set:
-        http_proxy: http://proxy.sandia.gov:80/
-        https_proxy: http://proxy.sandia.gov:80/
-    extra_rpaths: []
-- compiler:
-    spec: intel@2021.1.2
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    flags:
-      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-        -O2
-      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      prepend_path:
-        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
-        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
-        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    extra_rpaths: []
-- compiler:
-    spec: clang@12.0.1
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
     extra_rpaths: []

--- a/configs/ascicgpu/upstreams.yaml
+++ b/configs/ascicgpu/upstreams.yaml
@@ -1,0 +1,3 @@
+upstreams:
+  cde-v3:
+    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack

--- a/configs/ascicgpu/upstreams.yaml
+++ b/configs/ascicgpu/upstreams.yaml
@@ -1,3 +1,3 @@
 upstreams:
   cde-v3:
-    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack
+    install_tree: /projects/cde/v3/cee/spack/opt/spack/

--- a/configs/cee/compilers.yaml
+++ b/configs/cee/compilers.yaml
@@ -13,6 +13,20 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@8.3.1
+    environment: {}
+    extra_rpaths:
+    - /opt/rh/devtoolset-8/root/usr/lib64
+    modules: []
+    flags: {}
+    operating_system: rhel7
+    paths:
+      cc: /opt/rh/devtoolset-8/root/usr/bin/gcc
+      cxx: /opt/rh/devtoolset-8/root/usr/bin/g++
+      f77: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+      fc: /opt/rh/devtoolset-8/root/usr/bin/gfortran
+- compiler:
+    spec: gcc@7.2.0
     environment: {}
     extra_rpaths:
     - /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/lib64
@@ -26,7 +40,6 @@ compilers:
       cxx: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/g++
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
-    spec: gcc@7.2.0
     target: x86_64
 - compiler:
     spec: gcc@10.3.0

--- a/configs/cee/compilers.yaml
+++ b/configs/cee/compilers.yaml
@@ -29,12 +29,58 @@ compilers:
     spec: gcc@7.2.0
     target: x86_64
 - compiler:
-    spec: intel@19.0.3.199
+    spec: gcc@10.3.0
     paths:
-      cc: /projects/sierra/linux_rh7/SDK/compilers/intel/composer_xe_2019.3.199/compilers_and_libraries/linux/bin/intel64/icc
-      cxx: /projects/sierra/linux_rh7/SDK/compilers/intel/composer_xe_2019.3.199/compilers_and_libraries/linux/bin/intel64/icpc
-      f77: /projects/sierra/linux_rh7/SDK/compilers/intel/composer_xe_2019.3.199/compilers_and_libraries/linux/bin/intel64/ifort
-      fc: /projects/sierra/linux_rh7/SDK/compilers/intel/composer_xe_2019.3.199/compilers_and_libraries/linux/bin/intel64/ifort
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
+        -O2
+      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
+        -O2
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
+        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
+        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
+        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
+        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
+      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
+      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
+      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
     flags: {}
     operating_system: rhel7
     target: x86_64

--- a/configs/cee/compilers.yaml
+++ b/configs/cee/compilers.yaml
@@ -1,5 +1,62 @@
 compilers:
 - compiler:
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxxflags: -gxx-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      fflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+        C_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CPLUS_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        INCLUDE: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CMAKE_PREFIX_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+      set:
+        I_MPI_CC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+      cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+      f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@9.3.0
     paths:
       cc: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-tg7stm4b2owxiisgsu4rltm5im7pe7wz/bin/gcc
@@ -41,61 +98,4 @@ compilers:
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
     target: x86_64
-extra_rpaths: []
-- compiler:
-      spec: gcc@10.3.0
-      paths:
-        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
-        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
-        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-      flags: {}
-      operating_system: rhel7
-      target: x86_64
-      modules: []
-      environment:
-        set:
-          http_proxy: http://proxy.sandia.gov:80/
-          https_proxy: http://proxy.sandia.gov:80/
-      extra_rpaths: []
-  - compiler:
-      spec: intel@2021.1.2
-      paths:
-        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      flags:
-        cflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
-        cxxflags: -gxx-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
-        fflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
-      operating_system: rhel7
-      target: x86_64
-      modules: []
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
-          LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
-          PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
-          C_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-          CPLUS_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-          INCLUDE: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-          CMAKE_PREFIX_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
-        set:
-          I_MPI_CC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-          I_MPI_CXX: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-          I_MPI_FC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      extra_rpaths: []
-  - compiler:
-      spec: clang@12.0.1
-      paths:
-        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
-        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
-        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-      flags: {}
-      operating_system: rhel7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
+    extra_rpaths: []

--- a/configs/cee/compilers.yaml
+++ b/configs/cee/compilers.yaml
@@ -41,62 +41,61 @@ compilers:
       f77: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
       fc: /projects/sierra/linux_rh7/SDK/compilers/gcc/7.2.0-RHEL6/bin/gfortran
     target: x86_64
+extra_rpaths: []
 - compiler:
-    spec: gcc@10.3.0
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      set:
-        http_proxy: http://proxy.sandia.gov:80/
-        https_proxy: http://proxy.sandia.gov:80/
-    extra_rpaths: []
-- compiler:
-    spec: intel@2021.1.2
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    flags:
-      cflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-      cxxflags: -gxx-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/g++
-        -O2
-      fflags: -gcc-name=/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gcc
-        -O2
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      prepend_path:
-        LD_LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        LIBRARY_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib:/projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/lib64:/usr/lib/x86_64-redhat-linux6E/lib64
-        PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin
-        C_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        INCLUDE: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/include
-        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/
-        I_MPI_CC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-        I_MPI_CXX: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-        I_MPI_FC: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-    extra_rpaths: []
-- compiler:
-    spec: clang@12.0.1
-    paths:
-      cc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang
-      cxx: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-q2emwmczahi2fqpc7nmelpn2vcjguuqt/bin/clang++
-      f77: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-      fc: /projects/cde/dev/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-5syrderfben3b5m3soj5pg56ufredeoj/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
+      spec: gcc@10.3.0
+      paths:
+        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      flags: {}
+      operating_system: rhel7
+      target: x86_64
+      modules: []
+      environment:
+        set:
+          http_proxy: http://proxy.sandia.gov:80/
+          https_proxy: http://proxy.sandia.gov:80/
+      extra_rpaths: []
+  - compiler:
+      spec: intel@2021.1.2
+      paths:
+        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      flags:
+        cflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+        cxxflags: -gxx-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+        fflags: -gcc-name=/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      operating_system: rhel7
+      target: x86_64
+      modules: []
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+          LIBRARY_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+          PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+          C_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+          CPLUS_INCLUDE_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+          INCLUDE: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+          CMAKE_PREFIX_PATH: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+        set:
+          I_MPI_CC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+          I_MPI_CXX: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+          I_MPI_FC: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      extra_rpaths: []
+  - compiler:
+      spec: clang@12.0.1
+      paths:
+        cc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+        cxx: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+        f77: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+        fc: /projects/cde/v3/cee/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      flags: {}
+      operating_system: rhel7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []

--- a/configs/cee/upstreams.yaml
+++ b/configs/cee/upstreams.yaml
@@ -1,0 +1,3 @@
+upstreams:
+  cde-v3:
+    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack

--- a/configs/cee/upstreams.yaml
+++ b/configs/cee/upstreams.yaml
@@ -1,3 +1,3 @@
 upstreams:
   cde-v3:
-    install_tree: /projects/cde/dev/v3/cee/spack/opt/spack
+    install_tree: /projects/cde/v3/cee/spack/opt/spack/

--- a/configs/snl-hpc/compilers.yaml
+++ b/configs/snl-hpc/compilers.yaml
@@ -1,18 +1,61 @@
 compilers:
 - compiler:
-    environment: {}
-    extra_rpaths:
-    - /projects/global/toss3/compilers/intel/intel_2019/compilers_and_libraries_2019.3.199/linux/compiler/lib/intel64
-    modules: [sierra-compiler/intel/19.0.3]
+    spec: gcc@10.3.0
+    paths:
+      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
     flags: {}
     operating_system: rhel7
-    paths:
-      cc: /projects/global/toss3/compilers/intel/intel_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/icc
-      cxx: /projects/global/toss3/compilers/intel/intel_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/icpc
-      f77: /projects/global/toss3/compilers/intel/intel_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/ifort
-      fc: /projects/global/toss3/compilers/intel/intel_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/ifort
-    spec: intel@19.0.3.199
     target: x86_64
+    modules: []
+    environment:
+      set:
+        http_proxy: http://proxy.sandia.gov:80/
+        https_proxy: http://proxy.sandia.gov:80/
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.1.2
+    paths:
+      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    flags:
+      cflags: -gcc-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxxflags: -gxx-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      fflags: -gcc-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment:
+      prepend_path:
+        LD_LIBRARY_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        LIBRARY_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+        C_INCLUDE_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        INCLUDE: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+      set:
+        I_MPI_CC: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: [
 - compiler:
     environment: {}
     extra_rpaths:

--- a/configs/snl-hpc/compilers.yaml
+++ b/configs/snl-hpc/compilers.yaml
@@ -55,7 +55,7 @@ compilers:
     target: x86_64
     modules: []
     environment: {}
-    extra_rpaths: [
+    extra_rpaths: []
 - compiler:
     environment: {}
     extra_rpaths:

--- a/configs/snl-hpc/compilers.yaml
+++ b/configs/snl-hpc/compilers.yaml
@@ -1,55 +1,55 @@
 compilers:
 - compiler:
-    spec: gcc@10.3.0
-    paths:
-      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
-      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
-      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment:
-      set:
-        http_proxy: http://proxy.sandia.gov:80/
-        https_proxy: http://proxy.sandia.gov:80/
-    extra_rpaths: []
+      spec: gcc@10.3.0
+      paths:
+        cc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+        cxx: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+        f77: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+        fc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      flags: {}
+      operating_system: rhel7
+      target: x86_64
+      modules: []
+      environment:
+        set:
+          http_proxy: http://proxy.sandia.gov:80/
+          https_proxy: http://proxy.sandia.gov:80/
+      extra_rpaths: []
 - compiler:
     spec: intel@2021.1.2
     paths:
-      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
-      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      cc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+      cxx: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+      f77: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+      fc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
     flags:
-      cflags: -gcc-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
-      cxxflags: -gxx-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
-      fflags: -gcc-name=/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cflags: -gcc-name=/projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
+      cxxflags: -gxx-name=/projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/g++
+      fflags: -gcc-name=/projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
     environment:
       prepend_path:
-        LD_LIBRARY_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
-        LIBRARY_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
-        PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
-        C_INCLUDE_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-        CPLUS_INCLUDE_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-        INCLUDE: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
-        CMAKE_PREFIX_PATH: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
+        LD_LIBRARY_PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        LIBRARY_PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib:/projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/lib64
+        PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin
+        C_INCLUDE_PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CPLUS_INCLUDE_PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        INCLUDE: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/include
+        CMAKE_PREFIX_PATH: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/
       set:
-        I_MPI_CC: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
-        I_MPI_CXX: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
-        I_MPI_FC: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
+        I_MPI_CC: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icc
+        I_MPI_CXX: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/icpc
+        I_MPI_FC: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/intel-oneapi-compilers-2021.1.2-lufoj3442adjwmyj2djuozq5aec3ofn2/compiler/2021.1.2/linux/bin/intel64/ifort
     extra_rpaths: []
 - compiler:
     spec: clang@12.0.1
     paths:
-      cc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
-      cxx: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
-      f77: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
-      fc: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      cc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang
+      cxx: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-10.3.0/llvm-12.0.1-4ld5bciw4oetcntm2hgn23pklymf55ou/bin/clang++
+      f77: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
+      fc: /projects/cde/v3/tlcc2/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/gcc-10.3.0-bxx4ufppf7l3xlbvdinnusa4e6ykqok5/bin/gfortran
     flags: {}
     operating_system: rhel7
     target: x86_64

--- a/configs/snl-hpc/packages.yaml
+++ b/configs/snl-hpc/packages.yaml
@@ -3,13 +3,7 @@ packages:
     permissions:
       read: group
       group: wg-sierra-users
-    compiler:
-    - intel@19.0.3.199
-    - gcc@8.3.1
     providers:
-      mpi:
-      - mpich
-      - openmpi
       blas:
       - netlib-lapack
       lapack:

--- a/configs/snl-hpc/upstreams.yaml
+++ b/configs/snl-hpc/upstreams.yaml
@@ -1,0 +1,3 @@
+upstreams:
+  cde-v3:
+    install_tree: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/

--- a/configs/snl-hpc/upstreams.yaml
+++ b/configs/snl-hpc/upstreams.yaml
@@ -1,3 +1,3 @@
 upstreams:
   cde-v3:
-    install_tree: /projects/cde/dev/v3/develop/tlcc2/spack/opt/spack/
+    install_tree: /projects/cde/v3/tlcc2/spack/opt/spack/

--- a/start.sh
+++ b/start.sh
@@ -26,6 +26,11 @@ if [[ ! -x $(which python3) ]]; then
   echo "You may use spack, but spack-manager specific commands will fail."
 fi
 
+# convenience function for getting to the spack-manager directory
+function go-to-sm(){
+  cd ${SPACK_MANAGER}
+}
+
 # function to initialize spack-manager's spack instance
 function spack-start() {
   source $SPACK_MANAGER/scripts/spack_start.sh
@@ -45,13 +50,13 @@ function quick-create() {
     echo "*************************************************************
 HELP MESSAGE:
 quick-create sets up a basic spack environment
-    
+
 The next typical steps after running this command are to add specs
 and calling spack manager develop to clone dev specs, adding externals
 etc.
 
 The base command and it's help are echoed below:
-    
+
 "
     cmd "spack manager create-env $@"
     echo "*************************************************************"
@@ -79,9 +84,9 @@ from the default repos
 
 The next typical steps after running this command are to add externals if
 you want them, or run spack install.
-    
+
 The base command and it's help are echoed below:
-    
+
 "
     cmd "spack manager create-dev-env $@"
     echo "*************************************************************"
@@ -109,7 +114,7 @@ function quick-develop() {
     echo "*************************************************************
 HELP MESSAGE:
 quick-develop sets up a developer environment and installs it
-    
+
 This command is designed to require minimal arguments and simple setup
 with the caveat of accepting all the defaults for:
 
@@ -117,7 +122,7 @@ with the caveat of accepting all the defaults for:
 - latest external snapshot with the default compilers/configurations
 
 The base command and it's help are echoed below:
-    
+
 "
     cmd "spack manager create-dev-env $@"
     echo "*************************************************************"


### PR DESCRIPTION
This adds upstreams for the work done on tlcc2 and cee machines by the CDE project.  With these changes we will be utilizing their compilers and builds directly through spack.

I also copied the compilers.yaml between all the cee based machines since they were all using the same compilers anyways (minus the 2019 intel compiler no one was using; I deleted that one here too )

Closes #256 
Supersedes #283