### PR TITLE
Changed && to ; between shell commands to ensure submodules are properly updated

### DIFF
--- a/scripts/update-spack-manager-repo.sh
+++ b/scripts/update-spack-manager-repo.sh
@@ -13,4 +13,4 @@
 printf "Job is running on ${HOSTNAME}\n"
 printf "\nRun at $(date)\n"
 printf "\nUpdating spack-manager repo...\n"
-(set -x; pwd && git fetch --all && git reset --hard origin/main && git clean -df && git submodule update && git status -uno) 2>&1
+(set -x; pwd; git fetch --all; git reset --hard origin/main; git clean -df; git submodule update; git status -uno) 2>&1


### PR DESCRIPTION
Changed && to ; between shell commands to ensure submodules are properly updated even in the event that a previous command fails.

Closes #297 