### PR TITLE
Turn Ascent on by default for Exawind

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -1,4 +1,10 @@
 packages:
+  amr-wind:
+    variants: +ascent
+  ascent:
+    variants: ~fortran
+  conduit:
+    variants: ~fortran~hdf5_compat
   boost:
     version: [1.76.0]
     variants: cxxstd=14

--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -95,6 +95,10 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies('^amr-wind+hdf5'):
             args.append(define('H5Z_ZFP_USE_STATIC_LIBS', True))
 
+        if spec.satisfies('^amr-wind+ascent'):
+            # Necessary on Crusher to successfully find OpenMP
+            args.append(define('CMAKE_EXE_LINKER_FLAGS', self.compiler.openmp_flag))
+
         return args
 
     def setup_build_environment(self, env):

--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -53,7 +53,7 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('trilinos+rocm amdgpu_target=%s' % arch, when='+nalu_wind_gpu+rocm amdgpu_target=%s' % arch)
 
     depends_on('nalu-wind+tioga')
-    depends_on('amr-wind+hdf5+netcdf+mpi')
+    depends_on('amr-wind+hdf5+netcdf+mpi+ascent^conduit~hdf5_compat')
     depends_on('tioga+shared~nodegid')
     depends_on('yaml-cpp@0.6:')
     depends_on('nalu-wind+openfast', when='+openfast')

--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -53,7 +53,7 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('trilinos+rocm amdgpu_target=%s' % arch, when='+nalu_wind_gpu+rocm amdgpu_target=%s' % arch)
 
     depends_on('nalu-wind+tioga')
-    depends_on('amr-wind+hdf5+netcdf+mpi+ascent^ascent~fortran^conduit~fortran~hdf5_compat')
+    depends_on('amr-wind+hdf5+netcdf+mpi')
     depends_on('tioga+shared~nodegid')
     depends_on('yaml-cpp@0.6:')
     depends_on('nalu-wind+openfast', when='+openfast')

--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -53,7 +53,7 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('trilinos+rocm amdgpu_target=%s' % arch, when='+nalu_wind_gpu+rocm amdgpu_target=%s' % arch)
 
     depends_on('nalu-wind+tioga')
-    depends_on('amr-wind+hdf5+netcdf+mpi+ascent^conduit~hdf5_compat')
+    depends_on('amr-wind+hdf5+netcdf+mpi+ascent^ascent~fortran^conduit~fortran~hdf5_compat')
     depends_on('tioga+shared~nodegid')
     depends_on('yaml-cpp@0.6:')
     depends_on('nalu-wind+openfast', when='+openfast')


### PR DESCRIPTION
This works for me on Eagle, Summit, and Crusher. I think we should have this enabled like HDF5 is for AMR-Wind so people can use either of these for large simulations. I need to do more testing of this first though. Exawind links to so many things.