### PR TITLE
Allow the gold files generated in nightly testing to be placed in an arbitrary directory

### DIFF
--- a/repos/exawind/packages/amr-wind/package.py
+++ b/repos/exawind/packages/amr-wind/package.py
@@ -80,8 +80,9 @@ class AmrWind(bAmrWind):
             cmake_options.append('-DGPU_TARGETS=' + ';'.join(str(x) for x in targets))
 
         if '+tests' in spec:
-            saved_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds', 'tmp', 'amr-wind')
-            current_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds', 'current', 'amr-wind')
+            spack_manager_local_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds')
+            saved_golds = os.path.join(os.getenv('SPACK_MANAGER_GOLDS_DIR', default=spack_manager_local_golds), 'tmp', 'amr-wind')
+            current_golds = os.path.join(spack_manager_local_golds, 'current', 'amr-wind')
             os.makedirs(saved_golds, exist_ok=True)
             os.makedirs(current_golds, exist_ok=True)
             cmake_options.append(define('AMR_WIND_TEST_WITH_FCOMPARE', True))

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -65,8 +65,9 @@ class NaluWind(bNaluWind, ROCmPackage):
             cmake_options.append(define('MPIEXEC_PREFLAGS','--oversubscribe'))
 
         if spec.satisfies('+tests') or self.run_tests or spec.satisfies('dev_path=*'):
-            saved_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds', 'tmp', 'nalu-wind')
-            current_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds', 'current', 'nalu-wind')
+            spack_manager_local_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds')
+            saved_golds = os.path.join(os.getenv('SPACK_MANAGER_GOLDS', default=spack_manager_local_golds), 'tmp', 'nalu-wind')
+            current_golds = os.path.join(spack_manager_local_golds, 'current', 'nalu-wind')
             os.makedirs(saved_golds, exist_ok=True)
             os.makedirs(current_golds, exist_ok=True)
             cmake_options.append(define('NALU_WIND_SAVE_GOLDS', True))

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -66,7 +66,7 @@ class NaluWind(bNaluWind, ROCmPackage):
 
         if spec.satisfies('+tests') or self.run_tests or spec.satisfies('dev_path=*'):
             spack_manager_local_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds')
-            saved_golds = os.path.join(os.getenv('SPACK_MANAGER_GOLDS', default=spack_manager_local_golds), 'tmp', 'nalu-wind')
+            saved_golds = os.path.join(os.getenv('SPACK_MANAGER_GOLDS_DIR', default=spack_manager_local_golds), 'tmp', 'nalu-wind')
             current_golds = os.path.join(spack_manager_local_golds, 'current', 'nalu-wind')
             os.makedirs(saved_golds, exist_ok=True)
             os.makedirs(current_golds, exist_ok=True)

--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -30,11 +30,11 @@ else
     printf "\nSPACK_MANAGER set to ${SPACK_MANAGER}\n"
 fi
 
-if [[ -z ${SPACK_MANAGER_GOLDS} ]]; then
-    printf "\nSPACK_MANAGER_GOLDS not set so setting it to ${SPACK_MANAGER}/golds\n"
-    cmd "export SPACK_MANAGER_GOLDS=${SPACK_MANAGER}/golds"
+if [[ -z ${SPACK_MANAGER_GOLDS_DIR} ]]; then
+    printf "\nSPACK_MANAGER_GOLDS_DIR not set so setting it to ${SPACK_MANAGER}/golds\n"
+    cmd "export SPACK_MANAGER_GOLDS_DIR=${SPACK_MANAGER}/golds"
 else
-    printf "\nSPACK_MANAGER_GOLDS set to ${SPACK_MANAGER_GOLDS}\n"
+    printf "\nSPACK_MANAGER_GOLDS_DIR set to ${SPACK_MANAGER_GOLDS_DIR}\n"
 fi
 
 printf "\nActivating Spack-Manager...\n"
@@ -64,12 +64,12 @@ if [[ -f "${ENV_SCRIPT}" ]]; then
 fi
 
 printf "\nSetting up gold files directories...\n"
-cmd "rm -rf ${SPACK_MANAGER_GOLDS}/tmp/amr-wind"
-cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/tmp/amr-wind"
-cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/archived/amr-wind"
-cmd "rm -rf ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind"
-cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind"
-cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/archived/nalu-wind"
+cmd "rm -rf ${SPACK_MANAGER_GOLDS_DIR}/tmp/amr-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS_DIR}/tmp/amr-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS_DIR}/archived/amr-wind"
+cmd "rm -rf ${SPACK_MANAGER_GOLDS_DIR}/tmp/nalu-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS_DIR}/tmp/nalu-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS_DIR}/archived/nalu-wind"
 
 printf "\nSetting up Spack environoment...\n"
 cmd "export EXAWIND_ENV_DIR=${SPACK_MANAGER}/environments/exawind"
@@ -118,8 +118,8 @@ printf "\nTests ended at: $(date)\n"
 
 printf "\nSaving gold files...\n"
 DATE=$(date +%Y-%m-%d-%H-%M)
-cmd "tar -czf ${SPACK_MANAGER_GOLDS}/archived/amr-wind/amr-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS}/tmp/amr-wind ."
-cmd "tar -czf ${SPACK_MANAGER_GOLDS}/archived/nalu-wind/nalu-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind ."
+cmd "tar -czf ${SPACK_MANAGER_GOLDS_DIR}/archived/amr-wind/amr-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS_DIR}/tmp/amr-wind ."
+cmd "tar -czf ${SPACK_MANAGER_GOLDS_DIR}/archived/nalu-wind/nalu-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS_DIR}/tmp/nalu-wind ."
 
 #STAGE_DIR=$(spack location -S)
 #if [ ! -z "${STAGE_DIR}" ]; then

--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -30,6 +30,13 @@ else
     printf "\nSPACK_MANAGER set to ${SPACK_MANAGER}\n"
 fi
 
+if [[ -z ${SPACK_MANAGER_GOLDS} ]]; then
+    printf "\nSPACK_MANAGER_GOLDS not set so setting it to ${SPACK_MANAGER}/golds\n"
+    cmd "export SPACK_MANAGER_GOLDS=${SPACK_MANAGER}/golds"
+else
+    printf "\nSPACK_MANAGER_GOLDS set to ${SPACK_MANAGER_GOLDS}\n"
+fi
+
 printf "\nActivating Spack-Manager...\n"
 cmd "source ${SPACK_MANAGER}/start.sh && spack-start"
 
@@ -57,12 +64,12 @@ if [[ -f "${ENV_SCRIPT}" ]]; then
 fi
 
 printf "\nSetting up gold files directories...\n"
-cmd "rm -rf ${SPACK_MANAGER}/golds/tmp/amr-wind"
-cmd "mkdir -p ${SPACK_MANAGER}/golds/tmp/amr-wind"
-cmd "mkdir -p ${SPACK_MANAGER}/golds/archived/amr-wind"
-cmd "rm -rf ${SPACK_MANAGER}/golds/tmp/nalu-wind"
-cmd "mkdir -p ${SPACK_MANAGER}/golds/tmp/nalu-wind"
-cmd "mkdir -p ${SPACK_MANAGER}/golds/archived/nalu-wind"
+cmd "rm -rf ${SPACK_MANAGER_GOLDS}/tmp/amr-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/tmp/amr-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/archived/amr-wind"
+cmd "rm -rf ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind"
+cmd "mkdir -p ${SPACK_MANAGER_GOLDS}/archived/nalu-wind"
 
 printf "\nSetting up Spack environoment...\n"
 cmd "export EXAWIND_ENV_DIR=${SPACK_MANAGER}/environments/exawind"
@@ -111,8 +118,8 @@ printf "\nTests ended at: $(date)\n"
 
 printf "\nSaving gold files...\n"
 DATE=$(date +%Y-%m-%d-%H-%M)
-cmd "tar -czf ${SPACK_MANAGER}/golds/archived/amr-wind/amr-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER}/golds/tmp/amr-wind ."
-cmd "tar -czf ${SPACK_MANAGER}/golds/archived/nalu-wind/nalu-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER}/golds/tmp/nalu-wind ."
+cmd "tar -czf ${SPACK_MANAGER_GOLDS}/archived/amr-wind/amr-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS}/tmp/amr-wind ."
+cmd "tar -czf ${SPACK_MANAGER_GOLDS}/archived/nalu-wind/nalu-wind-golds-${DATE}.tar.gz -C ${SPACK_MANAGER_GOLDS}/tmp/nalu-wind ."
 
 #STAGE_DIR=$(spack location -S)
 #if [ ! -z "${STAGE_DIR}" ]; then


### PR DESCRIPTION
The environment variable `SPACK_MANAGER_GOLDS` can now be exported prior to running the testing script.  If it's not defined, the testing script will default to the current `$SPACK_MANAGER/golds`.