### PR TITLE
install nightly testing packages in serial

### DIFF
--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -113,7 +113,7 @@ cmd "spack clean -s || true"
 
 printf "\nTests started at: $(date)\n\n"
 printf "spack install \n"
-time (for i in {1..4}; do spack install --keep-stage & done; wait)
+time (spack install --keep-stage)
 printf "\nTests ended at: $(date)\n"
 
 printf "\nSaving gold files...\n"

--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -113,7 +113,11 @@ cmd "spack clean -s || true"
 
 printf "\nTests started at: $(date)\n\n"
 printf "spack install \n"
-time (spack install --keep-stage)
+if [ "${SPACK_MANAGER_MACHINE}" == 'ascicgpu' ]; then
+  time (spack install --keep-stage)
+else
+  time (for i in {1..4}; do spack install --keep-stage & done; wait)
+fi
 printf "\nTests ended at: $(date)\n"
 
 printf "\nSaving gold files...\n"


### PR DESCRIPTION
Turns out that the SNL GPU testing machines can't handle multiple tests running simultaneously.  #311 doesn't quite fix it, because unlike on eagle, we are building multiple variants of `nalu-wind-nightly` each time this script runs.  It seems that overlapping `spack install` commands allows spack to simultaneously install multiple `nalu-wind-nightly` packages, which can cause the tests to conflict with each other.

This PR removes the `spack install` loop, to force the test packages to be built in serial and guarantee they won't conflict with each other.

Related to Exawind/nalu-wind#994