### PR TITLE
Umpire Builds on OLCF

### DIFF
--- a/configs/crusher/packages.yaml
+++ b/configs/crusher/packages.yaml
@@ -91,6 +91,14 @@ packages:
         prefix: /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/openblas-0.3.17-54x7v5e4i6yxqs6j5nebrbztpy4lftj4
         modules:
           - openblas/0.3.17
+  umpire:
+    version: [6.0.0]
+    buildable: false
+    externals:
+      - spec: umpire@6.0.0
+        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.0/umpire-6.0.0-k6euxcfvl642cbaixqy4g2yircaobnot
+        modules:
+          - umpire/6.0.0
   all:
     compiler:
       - clang@14.0.0

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -148,3 +148,11 @@ packages:
       - spec: "boost@1.76.0%gcc"
         modules:
           - boost/1.76.0
+  umpire:
+    version: [6.0.0]
+    buildable: false
+    externals:
+      - spec: "umpire@6.0.0-no_omp-shared%gcc"
+        prefix: "/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-10.2.0/umpire-6.0.0-5qtgtts7nz2zunae7w7eeqgiqclb6uuv"
+        modules:
+          - umpire/6.0.0-no_omp-shared

--- a/repos/exawind/packages/hypre/package.py
+++ b/repos/exawind/packages/hypre/package.py
@@ -9,6 +9,8 @@ class Hypre(bHypre):
     variant('gpu-aware-mpi', default=False, description='Use gpu-aware mpi')
     variant('umpire', default=False, description='Use Umpire')
     depends_on("umpire", when='+umpire')
+    depends_on("umpire+rocm", when='+umpire+rocm')
+    depends_on("umpire+cuda", when='+umpire+cuda')
 
     def distclean(self, spec, prefix):
         with working_dir('src'):
@@ -28,7 +30,10 @@ class Hypre(bHypre):
             options.append('--enable-gpu-aware-mpi')
 
         if '+umpire' in spec:
+            if  (('+cuda' in spec or '+rocm' in spec) and "--enable-device-memory-pool" in options):
+                options.remove("--enable-device-memory-pool")
             options.append('--with-umpire')
+            options.append('--with-umpire-pinned')
             options.append('--with-umpire-include=%s'%(spec['umpire'].prefix.include))
             options.append('--with-umpire-lib-dirs=%s'%(spec['umpire'].prefix.lib))
             options.append('--with-umpire-libs=umpire')


### PR DESCRIPTION
Building umpire on crusher hasn't worked, however, we can hook into the system module. Also hypre needs to be told to hook into the right build of umpire when compiling for GPUs.

Tested on both crusher and summit.