### PR TITLE
update SNL configs to add buildable: false on MPI/Cuda packages

### DIFF
--- a/configs/ascic/packages.yaml
+++ b/configs/ascic/packages.yaml
@@ -18,3 +18,4 @@ packages:
       prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/
     - spec: mpich@3.4.2%gcc@8.3.1
       prefix: /projects/wind/spack-manager/views/system/gcc-8.3.1/mpich-3.4.2
+    buildable: false

--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -18,7 +18,9 @@ packages:
       prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/
     - spec: mpich@3.4.2%gcc@8.3.1
       prefix: /projects/wind/spack-manager/views/system/gcc-8.3.1/mpich-3.4.2
+    buildable: false
   cuda:
     externals:
     - spec: cuda@11.2.2%gcc@9.3.0
       prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/cuda-11.2.2-wlah7an4q7rej4uylqlimczaa6z3zlq7/
+    buildable: false

--- a/configs/cee/packages.yaml
+++ b/configs/cee/packages.yaml
@@ -15,6 +15,7 @@ packages:
     externals:
     - spec: openmpi@4.0.5%gcc@7.2.0
       prefix: /projects/sierra/linux_rh7/SDK/mpi/openmpi/4.0.5-gcc-7.2.0-RHEL7/
+    buildable: false
   pkg-config:
     buildable: false
     externals:
@@ -41,3 +42,4 @@ packages:
     externals:
     - spec: mpich@3.4.2%gcc@9.3.0
       prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/
+    buildable: false


### PR DESCRIPTION
This should be temporary -- related work for #333 or #314 may yield a better permanent solution for the packages.yaml callouts.