### PR TITLE
Add exawind repo on spack-start

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -24,9 +24,7 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   fi
   
   # need to add exawind repo so all packages are available to environments during creation 
-  if ! spack info nalu-wind-nightly >/dev/null 2>&1; then
-    spack repo add ${SPACK_MANAGER}/repos/exawind
-  fi
+  spack repo add ${SPACK_MANAGER}/repos/exawind >/dev/null 2>&1
   
   if [[ -z $(spack config --scope site blame bootstrap | grep spack-bootstrap-store) ]]; then
     if [[ "${SPACK_MANAGER_MACHINE}" == *"ascic"* || "${SPACK_MANAGER_MACHINE}" == "cee" ]]; then

--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -23,6 +23,11 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
     spack config --scope site add "config:extensions:[${SPACK_MANAGER}/spack-scripting]"
   fi
   
+  # need to add exawind repo so all packages are available to environments during creation 
+  if ! spack info nalu-wind-nightly >/dev/null 2>&1; then
+    spack repo add ${SPACK_MANAGER}/repos/exawind
+  fi
+  
   if [[ -z $(spack config --scope site blame bootstrap | grep spack-bootstrap-store) ]]; then
     if [[ "${SPACK_MANAGER_MACHINE}" == *"ascic"* || "${SPACK_MANAGER_MACHINE}" == "cee" ]]; then
       spack bootstrap add --scope site --trust wind-binaries /projects/wind/spack-bootstrap-store/metadata/binaries


### PR DESCRIPTION
Closes #350

I don't particularly like calling something as specific as `nalu-wind-nightly` in the start script, but I decided not to grep for the repo name like we do with the other checks because there is a non-trivial chance that `$SPACK_MANAGER` path could contain the word "exawind" for some users.  