### PR TITLE
WIP: Hip porting

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -27,11 +27,13 @@ class NaluWind(bNaluWind, ROCmPackage):
             description='Enable SIMD in STK')
     variant('ninja', default=False,
             description='Enable Ninja makefile generator')
+    variant('gpu-rdc', default=False,
+            description='Enable gpu-rdc for testing')
 
     depends_on('trilinos gotype=long')
 
     for arch in ROCmPackage.amdgpu_targets:
-        depends_on('trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm~rocm_rdc amdgpu_target=%s' % arch, when='+rocm amdgpu_target=%s' % arch)
+        depends_on('trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm amdgpu_target=%s' % arch, when='+rocm amdgpu_target=%s' % arch)
         depends_on('hypre+rocm amdgpu_target=%s' % arch, when='+hypre+rocm amdgpu_target=%s' % arch)
 
     cxxstd=['14', '17']
@@ -63,11 +65,14 @@ class NaluWind(bNaluWind, ROCmPackage):
             env.set('OMPI_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set('MPICH_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set('MPICXX_CXX', self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
+        if '+gpu-rdc' in self.spec:
+            env.append_flags('CXXFLAGS', '-fgpu-rdc')
 
     def cmake_args(self):
         spec = self.spec
         cmake_options = super(NaluWind, self).cmake_args()
         cmake_options.append(self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'))
+        cmake_options.append(self.define('CMAKE_VERBOSE_MAKEFILE', True))
 
         if  spec.satisfies('dev_path=*'):
             cmake_options.append(self.define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
@@ -76,6 +81,8 @@ class NaluWind(bNaluWind, ROCmPackage):
         if '+rocm' in self.spec:
             cmake_options.append('-DCMAKE_CXX_COMPILER={0}'.format(self.spec['hip'].hipcc))
             cmake_options.append(self.define('ENABLE_ROCM', True))
+            targets = spec.variants['amdgpu_target'].value
+            cmake_options.append('-DGPU_TARGETS=' + ';'.join(str(x) for x in targets))
 
         if spec['mpi'].name == 'openmpi':
             cmake_options.append(self.define('MPIEXEC_PREFLAGS','--oversubscribe'))

--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -19,7 +19,7 @@ class Trilinos(bTrilinos):
     variant('ninja', default=False,
             description='Enable Ninja makefile generator')
 
-    patch('kokkos_zero_length_team.patch')
+    #patch('kokkos_zero_length_team.patch')
 
     depends_on("ninja", type="build", when='+ninja')
 
@@ -78,5 +78,46 @@ class Trilinos(bTrilinos):
             options.append('-DCMAKE_HIP_ARCHITECTURES=' + ';'.join(str(x) for x in targets))
             options.append('-DAMDGPU_TARGETS=' + ';'.join(str(x) for x in targets))
             options.append('-DGPU_TARGETS=' + ';'.join(str(x) for x in targets))
+            options.append("-DTPL_ENABLE_Boost=OFF")
+            options.append("-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF")
+            options.append("-DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF")
+            options.append("-DTrilinos_ASSERT_MISSING_PACKAGES=OFF")
+            options.append("-DTrilinos_ENABLE_Fortran:BOOL=OFF")
+            # Kokkos
+            options.append("-DTrilinos_ENABLE_Kokkos:BOOL=ON")
+            options.append("-DKokkos_ENABLE_HIP:BOOL=ON")
+            options.append("-DKokkos_ARCH_ZEN2:BOOL=OFF")
+            options.append("-DKokkos_ARCH_ZEN3:BOOL=ON")
+            options.append("-DKokkos_ARCH_VEGA90A:BOOL=ON")
+            options.append("-DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE:BOOL=ON")
+            # Tests
+            options.append("-DTrilinos_ENABLE_SEACAS:BOOL=ON")
+            options.append("-DSEACASExodus_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASIoss_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASNemesis_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASEpu_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASExodiff_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASNemspread_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASNemslice_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASChaco_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSEACASAprepro_ENABLE_TESTS:BOOL=OFF")
 
+            options.append("-DTrilinos_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DSTK_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DIfpack2_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DMueLu_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DPanzerMiniEM_ENABLE_TESTS:BOOL=OFF")
+            options.append("-DTpetra_INST_HIP:BOOL=ON")
+            options.append("-DTpetra_ENABLE_TESTS:BOOL=OFF")
+            # STK
+            options.append("-DTrilinos_ENABLE_STK:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKMesh:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKIO:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKBalance:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKMath:BOOL=ON",)
+            options.append("-DTrilinos_ENABLE_STKSearch:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKTransfer:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKTopology:BOOL=ON")
+            options.append("-DTrilinos_ENABLE_STKUtils=ON")
+            options.append("-DTrilinos_ENABLE_STKTools=ON")
         return options


### PR DESCRIPTION
This branch has some of the mods necessary for building on Crusher. It needs to be cleaned up and several outstanding issues need to be resolved.

1) It was necessary to add --hip-link to the link line of nalu via the nalu-wind CMakeLists.txt file (i.e. target_link_libraries(${nalu_ex_name} PRIVATE nalu -fgpu-rdc --hip-link) 
This is a hack that needs to be fixed through spack-manager.

2) The build only succeeds in Release mode. RelWithDebInfo and Debug builds fail at the link stage with:
unhandled SGPR spill to memory
This may be a known compiler bug that AMD is actively trying to fix. In the meantime, we should try to warn or prevent people from building with debug symbols.