### PR TITLE
use release build of openfast for SNL nightlies

### DIFF
--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -5,12 +5,12 @@ spack:
     unify: false
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Debug ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Debug ^trilinos@develop'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@stable ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@stable ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@stable ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Debug ^trilinos@stable ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@develop ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@develop ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@develop ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Debug ^trilinos@develop ^openfast@master build_type=Release'
     - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast %clang@12.0.1 build_type=Release ^trilinos@develop'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -5,13 +5,13 @@ spack:
     unify: false
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable+uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable+uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop+uvm ^openfast@master build_type=Release'
     - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable~uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable~uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm ^openfast@master build_type=Release'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop~uvm ^openfast@master build_type=Release'
     - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'


### PR DESCRIPTION
seems to avoid an openfast segfault for clang with lower levels of optimization.