### PR TITLE
Modify Snapshots to use GitHash versions

### DIFF
--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -22,8 +22,10 @@ import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
 import spack.util.executable
-from spack.version import GitVersion, Version
 import spack.cmd.install
+
+from spack.version import GitVersion, Version
+from spack.spec import Spec
 
 
 git = spack.util.executable.which('git')
@@ -278,6 +280,12 @@ def replace_versions_with_hashes(spec_string, hash_dict):
     for spec in specs:
         base, rest = spec.split('%')
         name, version = base.split('@')
+
+        # use paired version if it is already a GitVersion
+        newSpec  = Spec(spec)
+        if isinstance(newSpec.version, GitVersion):
+            version = newSpec.version.ref_version_str
+
         hash = hash_dict.get(name)
         if hash:
             version = 'git.{hash}={version}'.format(hash=hash,version=version)

--- a/scripts/snapshot_creator.py
+++ b/scripts/snapshot_creator.py
@@ -238,9 +238,9 @@ def get_top_level_specs(env, blacklist=blacklist):
 
 def find_latest_git_hash(spec):
     if isinstance(spec.version, GitVersion):
-        # if it is already a GitVersion then we've probably already ran this once
-        # we are going to recreate the paried version that the git hash has been
-        # assigned to and use that
+        # if it is already a GitVersion then we've probably already ran this
+        # once we are going to recreate the paried version that the git hash
+        # has been assigned to and use that
         version = Version(spec.version.ref_version_str)
         version_dict = spec.package_class.versions[version]
     else:
@@ -257,7 +257,8 @@ def find_latest_git_hash(spec):
         # already matched
         return None
     elif 'commit' in keys:
-        # we could reuse the commit, but since it is effectively pinned just return none
+        # we could reuse the commit, but since it is effectively pinned just
+        # return none
         return None
     else:
         raise Exception(
@@ -282,23 +283,25 @@ def replace_versions_with_hashes(spec_string, hash_dict):
         name, version = base.split('@')
 
         # use paired version if it is already a GitVersion
-        newSpec  = Spec(spec)
+        newSpec = Spec(spec)
         if isinstance(newSpec.version, GitVersion):
             version = newSpec.version.ref_version_str
 
         hash = hash_dict.get(name)
         if hash:
-            version = 'git.{hash}={version}'.format(hash=hash,version=version)
-            # prune the spec string to get rid of patches which could cause conflicts later
+            version = 'git.{hash}={version}'.format(hash=hash, version=version)
+            # prune the spec string to get rid of patches which could cause
+            # conflicts later
             new_specs.append(pruned_spec_string('{n}@{v}%{r}'.format(n=name,
-                                                  v=version, r=rest)))
+                                                                     v=version,
+                                                                     r=rest)))
     final = ' ^'.join(new_specs)
     assert '\n' not in final
     assert '\t' not in final
     return final
 
 
-def use_latest_git_hashes(env, top_specs, blacklist=blacklist):
+def use_latest_git_hashes(env, blacklist=blacklist):
     with open(env.manifest_path, 'r') as f:
         yaml = syaml.load(f)
 
@@ -314,8 +317,7 @@ def use_latest_git_hashes(env, top_specs, blacklist=blacklist):
                     hash_dict[dep.name] = find_latest_git_hash(dep)
 
             yaml['spack']['specs'][i] = replace_versions_with_hashes(
-               roots[i].build_spec, hash_dict)
-            # yaml['spack']['specs'][i] = str(roots[i].build_spec)
+                roots[i].build_spec, hash_dict)
 
     with open(env.manifest_path, 'w') as fout:
         syaml.dump_config(yaml, stream=fout,
@@ -382,7 +384,7 @@ def create_snapshots(args):
     if args.use_develop:
         use_develop_specs(e, top_specs)
     else:
-        use_latest_git_hashes(e, top_specs)
+        use_latest_git_hashes(e)
 
     if args.stop_after == 'mod_specs':
         return

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -9,7 +9,7 @@ import os
 import re
 from datetime import datetime
 
-from manager_utils import base_extension
+from manager_utils import base_extension, pruned_spec_string
 
 import llnl.util.tty as tty
 
@@ -98,7 +98,7 @@ def add_include_entry(env, inc, prepend=True):
 
 def create_external_detected_spec(env, spec):
     view = _get_first_view_containing_spec(env, spec)
-    pruned_spec = _well_posed_spec_string_minus_dev_path(spec)
+    pruned_spec = pruned_spec_string(spec)
     prefix = view.get_projection_for_spec(spec)
     return spack.detection.DetectedPackage(Spec.from_detection(pruned_spec), prefix)
 
@@ -136,23 +136,6 @@ def create_yaml_from_detected_externals(ext_dict):
         formatted_dict[name] = config
 
     return syaml.syaml_dict({"packages": formatted_dict})
-
-
-def _well_posed_spec_string_minus_dev_path(spec):
-    full_spec = spec.format("{name}{@version}{%compiler}{variants}{arch=architecture}")
-    spec_components = full_spec.split(" ")
-    variants_to_omit = ("dev_path=", "patches=")
-
-    def filter_func(entry):
-        for v in variants_to_omit:
-            if v in entry:
-                return False
-        return True
-
-    pruned_components = list(filter(filter_func, spec_components))
-
-    pruned_spec = " ".join(pruned_components)
-    return pruned_spec
 
 
 def _get_first_view_containing_spec(env, spec):

--- a/spack-scripting/scripting/manager_utils.py
+++ b/spack-scripting/scripting/manager_utils.py
@@ -27,7 +27,7 @@ def path_extension(name, use_machine_name):
     )
 
 
-def pruned_spec_string(spec, variants_to_omit = ["dev_path=", "patches="]):
+def pruned_spec_string(spec, variants_to_omit=["dev_path=", "patches="]):
     full_spec = spec.format("{name}{@version}{%compiler}{variants}{arch=architecture}")
     spec_components = full_spec.split(" ")
 

--- a/spack-scripting/scripting/manager_utils.py
+++ b/spack-scripting/scripting/manager_utils.py
@@ -25,3 +25,19 @@ def path_extension(name, use_machine_name):
         base_extension(use_machine_name),
         "{date}".format(date=name if name else date.today().strftime("%Y-%m-%d")),
     )
+
+
+def pruned_spec_string(spec, variants_to_omit = ["dev_path=", "patches="]):
+    full_spec = spec.format("{name}{@version}{%compiler}{variants}{arch=architecture}")
+    spec_components = full_spec.split(" ")
+
+    def filter_func(entry):
+        for v in variants_to_omit:
+            if v in entry:
+                return False
+        return True
+
+    pruned_components = list(filter(filter_func, spec_components))
+
+    pruned_spec = " ".join(pruned_components)
+    return pruned_spec

--- a/spack-scripting/tests/test_external.py
+++ b/spack-scripting/tests/test_external.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import manager_cmds
 import manager_cmds.external
 import pytest
+from manager_utils import pruned_spec_string
 
 import spack.environment as ev
 import spack.main
@@ -35,7 +36,7 @@ manager = spack.main.SpackCommand("manager")
 def test_stripDevPathFromExternals(spec_str):
     assert "dev_path" in spec_str
     s = Spec(spec_str)
-    pruned_string = manager_cmds.external._well_posed_spec_string_minus_dev_path(s)
+    pruned_string = pruned_spec_string(s)
     assert "dev_path" not in pruned_string
 
 
@@ -52,7 +53,7 @@ def test_stripDevPathFromExternals(spec_str):
 def test_stripPatchesFromExternals(spec_str):
     assert "patches" in spec_str
     s = Spec(spec_str)
-    pruned_string = manager_cmds.external._well_posed_spec_string_minus_dev_path(s)
+    pruned_string = pruned_spec_string(s)
     assert "patches" not in pruned_string
 
 


### PR DESCRIPTION
Update snapshot creation process to use git hashes as versions instead of develop specs.  This should save on storage and reuse quite a bit.

This should also allow for a parallel DAG build again since hypre will have separate sources for separate installs.

It should be noted that the modules don't seem like they will work anymore with the projections.  I'm not sure what to do about this yet.  It seems like we may need to do a view module pair per root spec again.

Looking back over old conversations I think the separate build directories will solve the issues we were seeing with 1 view per root spec.  However I think we should test that out in a follow on PR after we merge this.