### PR TITLE
be more specific about user cache/config paths

### DIFF
--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -41,7 +41,12 @@ printf "\nActivating Spack-Manager...\n"
 cmd "source ${SPACK_MANAGER}/start.sh && spack-start"
 
 printf "\nCleaning Spack installation...\n"
-cmd "spack clean --all"
+  echo "Remove Spack-Manager cache:"
+  cmd "rm -rf ${SPACK_MANAGER}/.cache"
+  echo "Use the native Spack clean system":
+  cmd "spack clean --all"
+  echo "Cleaning out pycache from spack-manager repos:"
+  cmd "find ${SPACK_MANAGER}/repos -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete"
 
 printf "\nGenerating test script for submission...\n"
 EXAWIND_TEST_SCRIPT=${SPACK_MANAGER}/scripts/exawind-tests-script.sh

--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -41,7 +41,7 @@ printf "\nActivating Spack-Manager...\n"
 cmd "source ${SPACK_MANAGER}/start.sh && spack-start"
 
 printf "\nCleaning Spack installation...\n"
-cmd "sm-clean"
+cmd "spack clean --all"
 
 printf "\nGenerating test script for submission...\n"
 EXAWIND_TEST_SCRIPT=${SPACK_MANAGER}/scripts/exawind-tests-script.sh

--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -12,6 +12,7 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   export SPACK_ROOT=${SPACK_MANAGER}/spack
   export SPACK_DISABLE_LOCAL_CONFIG=true
   export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
+  export SPACK_USER_CONFIG_PATH=${SPACK_MANAGER}/.config
   export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd:${SPACK_MANAGER}/spack-scripting/scripting
   source ${SPACK_ROOT}/share/spack/setup-env.sh
 

--- a/start.sh
+++ b/start.sh
@@ -194,9 +194,9 @@ function sm-clean(){
     return
   fi
   echo "Remove user cache of configs:"
-  cmd "rm -rf ${SPACK_USER_CONFIG_PATH}"
+  cmd "rm -rf ~/.spack"
   echo "Remove Spack-Manager cache:"
-  cmd "rm -rf ${SPACK_USER_CACHE_PATH}"
+  cmd "rm -rf ${SPACK_MANAGER}/.cache"
   echo "Use the native Spack clean system":
   cmd "spack clean --all"
   echo "Cleaning out pycache from spack-manager repos:"

--- a/start.sh
+++ b/start.sh
@@ -194,9 +194,9 @@ function sm-clean(){
     return
   fi
   echo "Remove user cache of configs:"
-  cmd "rm -rf ~/.spack"
+  cmd "rm -rf ${SPACK_USER_CONFIG_PATH}"
   echo "Remove Spack-Manager cache:"
-  cmd "rm -rf ${SPACK_MANAGER}/.cache"
+  cmd "rm -rf ${SPACK_USER_CACHE_PATH}"
   echo "Use the native Spack clean system":
   cmd "spack clean --all"
   echo "Cleaning out pycache from spack-manager repos:"


### PR DESCRIPTION
After discovering that spack has both the `SPACK_USER_CACHE_PATH` and `SPACK_USER_CONFIG_PATH`, I realized that the first two lines of `sm-clean` are really just deleting both those directories.  This PR would make that explicit by using those env variables to specify what to delete.

In order to make this work, we need to make sure `SPACK_USER_CONFIG_PATH` is actually set in `spack-start`.  Setting it to a location inside `$SPACK_MANAGER` makes it so `sm-clean` will not accidentally blow away configs/caches needed by other spack installations.