### PR TITLE
disable Fortran in hypre

### DIFF
--- a/repos/exawind/packages/hypre/package.py
+++ b/repos/exawind/packages/hypre/package.py
@@ -48,4 +48,8 @@ class Hypre(bHypre):
             options.append('--with-umpire-lib-dirs=%s'%(spec['umpire'].prefix.lib))
             options.append('--with-umpire-libs=umpire')
 
+        if  ("--enable-fortran" in options):
+            options.remove("--enable-fortran")
+            options.append("--disable-fortran")
+
         return options


### PR DESCRIPTION
Part 2 of breakup of #352.  I think this is not strictly required for ROCm, but since it was on @PaulMullowney's branch I presume it is valuable and didn't want it to get lost.

@psakievich @jrood-nrel 