### PR TITLE
Add numeric versions to Trilinos and remove stable version

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -26,7 +26,7 @@ packages:
   yaml-cpp:
     version: [0.6.3]
   trilinos:
-    version: [stable, develop]
+    version: [13.4.0.2022.10.27, develop]
     variants: ~adios2~alloptpkgs~amesos+amesos2~anasazi~aztec+belos+boost~chaco~complex~debug~dtk~epetra~epetraext+exodus+explicit_template_instantiation~float~fortran~fortrilinos+glm+gtest+hdf5~hypre~ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos~mesquite+metis~minitensor~ml+mpi+muelu~mumps~nox~openmp~phalanx~piro~python~rol~rythmos~sacado+shards~shylu+stk~stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+uvm~x11~xsdkflags+zlib+zoltan+zoltan2 gotype=long cxxstd=14 build_type=Release
   all:
     variants: build_type=Release +mpi

--- a/env-templates/exawind_ascic_tests.yaml
+++ b/env-templates/exawind_ascic_tests.yaml
@@ -5,10 +5,10 @@ spack:
     unify: false
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@stable'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@12.0.1 build_type=Debug ^trilinos@stable'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@13.4.0.2022.10.27'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@13.4.0.2022.10.27'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@13.4.0.2022.10.27'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@12.0.1 build_type=Debug ^trilinos@13.4.0.2022.10.27'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@9.3.0 build_type=Release ^trilinos@develop'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@develop'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@12.0.1 build_type=Release ^trilinos@develop'

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -5,13 +5,13 @@ spack:
     unify: false
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@13.4.0.2022.10.27+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@13.4.0.2022.10.27+uvm'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop+uvm'
     - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@13.4.0.2022.10.27~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@13.4.0.2022.10.27~uvm'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop~uvm'
     - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'

--- a/env-templates/exawind_rhodes_tests.yaml
+++ b/env-templates/exawind_rhodes_tests.yaml
@@ -9,7 +9,7 @@ spack:
     #- 'exawind-nightly +hypre+openfast %intel@20.0.2'
     #- 'exawind-nightly +hypre+openfast %clang@10.0.0'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0'
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %intel@20.0.2'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast cxxstd=14 %intel@20.0.2 ^trilinos@13.2.0.2022.06.05'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+asan build_type=Debug %clang@10.0.0'
     - 'amr-wind-nightly +hypre+masa+netcdf %gcc@9.3.0'
     - 'amr-wind-nightly +hypre+masa+netcdf %intel@20.0.2'

--- a/repos/exawind/packages/amr-wind-nightly/package.py
+++ b/repos/exawind/packages/amr-wind-nightly/package.py
@@ -38,7 +38,6 @@ class AmrWindNightly(bAmrWind):
 
     def ctest_args(self):
         spec = self.spec
-        define = CMakePackage.define
         machine = find_machine(verbose=False, full_machine_name=True)
         if spec.variants['host_name'].value == 'default':
             if machine == 'NOT-FOUND':
@@ -60,19 +59,19 @@ class AmrWindNightly(bAmrWind):
 
         # Ctest options
         ctest_options = []
-        ctest_options.extend([define('TESTING_ROOT_DIR', self.stage.path),
-            define('SOURCE_DIR', self.stage.source_path),
-            define('BUILD_DIR', self.build_directory)])
+        ctest_options.extend([self.define('TESTING_ROOT_DIR', self.stage.path),
+            self.define('SOURCE_DIR', self.stage.source_path),
+            self.define('BUILD_DIR', self.build_directory)])
         if machine == 'eagle.hpc.nrel.gov':
-            ctest_options.append(define('CTEST_DISABLE_OVERLAPPING_TESTS', True))
-            ctest_options.append(define('UNSET_TMPDIR_VAR', True))
+            ctest_options.append(self.define('CTEST_DISABLE_OVERLAPPING_TESTS', True))
+            ctest_options.append(self.define('UNSET_TMPDIR_VAR', True))
             if '+cuda' in spec:
-                cmake_options.append(define('GPUS_PER_NODE', '2'))
-        ctest_options.append(define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
-        ctest_options.append(define('HOST_NAME', spec.variants['host_name'].value))
-        ctest_options.append(define('EXTRA_BUILD_NAME', spec.variants['extra_name'].value))
-        ctest_options.append(define('USE_LATEST_AMREX', spec.variants['latest_amrex'].value))
-        ctest_options.append(define('NP', spack.config.get('config:build_jobs')))
+                cmake_options.append(self.define('GPUS_PER_NODE', '2'))
+        ctest_options.append(self.define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
+        ctest_options.append(self.define('HOST_NAME', spec.variants['host_name'].value))
+        ctest_options.append(self.define('EXTRA_BUILD_NAME', spec.variants['extra_name'].value))
+        ctest_options.append(self.define('USE_LATEST_AMREX', spec.variants['latest_amrex'].value))
+        ctest_options.append(self.define('NP', spack.config.get('config:build_jobs')))
         ctest_options.append('-VV')
         ctest_options.append('-S')
         ctest_options.append(os.path.join(self.stage.source_path,'test','CTestNightlyScript.cmake'))

--- a/repos/exawind/packages/amr-wind/package.py
+++ b/repos/exawind/packages/amr-wind/package.py
@@ -28,7 +28,7 @@ class AmrWind(bAmrWind):
     depends_on('h5z-zfp', when='+hdf5')
     depends_on('zfp', when='+hdf5')
     depends_on("ninja", type="build", when='+ninja')
-    
+
     @property
     def generator(self):
           if '+ninja' in self.spec:
@@ -45,31 +45,30 @@ class AmrWind(bAmrWind):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
         cmake_options = super(AmrWind, self).cmake_args()
 
         if '+cppcheck' in spec:
-            cmake_options.append(define('AMR_WIND_ENABLE_CPPCHECK', True))
+            cmake_options.append(self.define('AMR_WIND_ENABLE_CPPCHECK', True))
 
         if '+clangtidy' in spec:
-            cmake_options.append(define('AMR_WIND_ENABLE_CLANG_TIDY', True))
+            cmake_options.append(self.define('AMR_WIND_ENABLE_CLANG_TIDY', True))
 
         if spec.satisfies('dev_path=*'):
-            cmake_options.append(define('CMAKE_EXPORT_COMPILE_COMMANDS', True))
+            cmake_options.append(self.define('CMAKE_EXPORT_COMPILE_COMMANDS', True))
 
         if '+cuda' in self.spec:
             targets = self.spec.variants['cuda_arch'].value
             cmake_options.append('-DCMAKE_CUDA_ARCHITECTURES=' + ';'.join(str(x) for x in targets))
 
         if '+hdf5' in spec:
-            cmake_options.append(define('AMR_WIND_ENABLE_HDF5', True))
-            cmake_options.append(define('AMR_WIND_ENABLE_HDF5_ZFP', True))
+            cmake_options.append(self.define('AMR_WIND_ENABLE_HDF5', True))
+            cmake_options.append(self.define('AMR_WIND_ENABLE_HDF5_ZFP', True))
             # Help AMReX understand if HDF5 is parallel or not.
             # Building HDF5 with CMake as Spack does, causes this inspection to break.
             if '+mpi' in spec:
-                cmake_options.append(define('HDF5_IS_PARALLEL', True))
+                cmake_options.append(self.define('HDF5_IS_PARALLEL', True))
             else:
-                cmake_options.append(define('HDF5_IS_PARALLEL', False))
+                cmake_options.append(self.define('HDF5_IS_PARALLEL', False))
 
         if '+rocm' in self.spec:
             # Used as an optimization to only list the single specified
@@ -86,10 +85,10 @@ class AmrWind(bAmrWind):
             current_golds = os.path.join(spack_manager_golds_dir, 'current', 'amr-wind')
             os.makedirs(saved_golds, exist_ok=True)
             os.makedirs(current_golds, exist_ok=True)
-            cmake_options.append(define('AMR_WIND_TEST_WITH_FCOMPARE', True))
-            cmake_options.append(define('AMR_WIND_SAVE_GOLDS', True))
-            cmake_options.append(define('AMR_WIND_SAVED_GOLDS_DIRECTORY', saved_golds))
-            cmake_options.append(define('AMR_WIND_REFERENCE_GOLDS_DIRECTORY', current_golds))
+            cmake_options.append(self.define('AMR_WIND_TEST_WITH_FCOMPARE', True))
+            cmake_options.append(self.define('AMR_WIND_SAVE_GOLDS', True))
+            cmake_options.append(self.define('AMR_WIND_SAVED_GOLDS_DIRECTORY', saved_golds))
+            cmake_options.append(self.define('AMR_WIND_REFERENCE_GOLDS_DIRECTORY', current_golds))
 
         return cmake_options
 

--- a/repos/exawind/packages/exawind-nightly/package.py
+++ b/repos/exawind/packages/exawind-nightly/package.py
@@ -24,19 +24,18 @@ class ExawindNightly(bExawind):
     def ctest_args(self):
         spec = self.spec
         options = []
-        define = CMakePackage.define
         cmake_options = self.std_cmake_args
         cmake_options += self.cmake_args()
         cmake_options.remove('-G')
         cmake_options.remove('Unix Makefiles') # The space causes problems for ctest
         if spec.variants['host_name'].value == 'default':
             spec.variants['host_name'].value = spec.format('{architecture}')
-        options.append(define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
-        options.append(define('CTEST_SOURCE_DIRECTORY', self.stage.source_path))
-        options.append(define('CTEST_BINARY_DIRECTORY', self.build_directory))
-        options.append(define('EXTRA_BUILD_NAME', spec.format('-{compiler}')))
-        options.append(define('HOST_NAME', spec.variants['host_name'].value))
-        options.append(define('NP', spack.config.get('config:build_jobs')))
+        options.append(self.define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
+        options.append(self.define('CTEST_SOURCE_DIRECTORY', self.stage.source_path))
+        options.append(self.define('CTEST_BINARY_DIRECTORY', self.build_directory))
+        options.append(self.define('EXTRA_BUILD_NAME', spec.format('-{compiler}')))
+        options.append(self.define('HOST_NAME', spec.variants['host_name'].value))
+        options.append(self.define('NP', spack.config.get('config:build_jobs')))
         options.append('-VV')
         options.append('-S')
         options.append(os.path.join(self.stage.source_path,'test','CTestNightlyScript.cmake'))

--- a/repos/exawind/packages/exawind/package.py
+++ b/repos/exawind/packages/exawind/package.py
@@ -79,31 +79,30 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         args = super(Exawind, self).cmake_args()
-        define = CMakePackage.define
 
         if spec.satisfies('dev_path=*'):
-            args.append(define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
+            args.append(self.define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
 
-        args.append(define('MPI_HOME', spec['mpi'].prefix))
+        args.append(self.define('MPI_HOME', spec['mpi'].prefix))
 
         if spec.satisfies('+cuda'):
-            args.append(define('EXAWIND_ENABLE_CUDA', True))
-            args.append(define('CUDAToolkit_ROOT', self.spec['cuda'].prefix))
+            args.append(self.define('EXAWIND_ENABLE_CUDA', True))
+            args.append(self.define('CUDAToolkit_ROOT', self.spec['cuda'].prefix))
 
         if spec.satisfies('+rocm'):
             targets = self.spec.variants['amdgpu_target'].value
-            args.append(define('EXAWIND_ENABLE_ROCM', True))
+            args.append(self.define('EXAWIND_ENABLE_ROCM', True))
             args.append('-DCMAKE_CXX_COMPILER={0}'.format(self.spec['hip'].hipcc))
             args.append('-DCMAKE_HIP_ARCHITECTURES=' + ';'.join(str(x) for x in targets))
             args.append('-DAMDGPU_TARGETS=' + ';'.join(str(x) for x in targets))
             args.append('-DGPU_TARGETS=' + ';'.join(str(x) for x in targets))
 
         if spec.satisfies('^amr-wind+hdf5'):
-            args.append(define('H5Z_ZFP_USE_STATIC_LIBS', True))
+            args.append(self.define('H5Z_ZFP_USE_STATIC_LIBS', True))
 
         if spec.satisfies('^amr-wind+ascent'):
             # Necessary on Crusher to successfully find OpenMP
-            args.append(define('CMAKE_EXE_LINKER_FLAGS', self.compiler.openmp_flag))
+            args.append(self.define('CMAKE_EXE_LINKER_FLAGS', self.compiler.openmp_flag))
 
         return args
 
@@ -113,7 +112,7 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
         if '+asan' in self.spec:
             env.append_flags("CXXFLAGS", "-fsanitize=address -fno-omit-frame-pointer -fsanitize-blacklist={0}".format(join_path(self.package_dir, 'sup.asan')))
         if '+rocm+amr_wind_gpu~nalu_wind_gpu' in self.spec:
-            # Manually turn off device defines to solve Kokkos issues in Nalu-Wind headers
+            # Manually turn off device self.defines to solve Kokkos issues in Nalu-Wind headers
             env.append_flags("CXXFLAGS", "-U__HIP_DEVICE_COMPILE__ -DDESUL_HIP_RDC")
         if '+rocm' in self.spec:
             env.set('OMPI_CXX', self.spec['hip'].hipcc)

--- a/repos/exawind/packages/nalu-wind-nightly/package.py
+++ b/repos/exawind/packages/nalu-wind-nightly/package.py
@@ -59,7 +59,6 @@ class NaluWindNightly(bNaluWind, CudaPackage):
 
     def ctest_args(self):
         spec = self.spec
-        define = CMakePackage.define
         machine = find_machine(verbose=False)
         full_machine = find_machine(verbose=False, full_machine_name=True)
 
@@ -80,21 +79,21 @@ class NaluWindNightly(bNaluWind, CudaPackage):
         if '%intel' in spec and '-DBoost_NO_BOOST_CMAKE=ON' in cmake_options:
             cmake_options.remove('-DBoost_NO_BOOST_CMAKE=ON') # Avoid dashboard warning
         if full_machine == 'eagle.hpc.nrel.gov' or 'ascicgpu' in machine:
-            cmake_options.append(define('TEST_ABS_TOL', '1e-10'))
-            cmake_options.append(define('TEST_REL_TOL', '1e-8'))
+            cmake_options.append(self.define('TEST_ABS_TOL', '1e-10'))
+            cmake_options.append(self.define('TEST_REL_TOL', '1e-8'))
 
         # Ctest options
         ctest_options = []
-        ctest_options.extend([define('TESTING_ROOT_DIR', self.stage.path),
-            define('NALU_DIR', self.stage.source_path),
-            define('BUILD_DIR', self.build_directory)])
+        ctest_options.extend([self.define('TESTING_ROOT_DIR', self.stage.path),
+            self.define('NALU_DIR', self.stage.source_path),
+            self.define('BUILD_DIR', self.build_directory)])
         if full_machine == 'eagle.hpc.nrel.gov' or machine == 'ascicgpu':
-            ctest_options.append(define('CTEST_DISABLE_OVERLAPPING_TESTS', True))
-            ctest_options.append(define('UNSET_TMPDIR_VAR', True))
-        ctest_options.append(define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
-        ctest_options.append(define('HOST_NAME', spec.variants['host_name'].value))
-        ctest_options.append(define('EXTRA_BUILD_NAME', spec.variants['extra_name'].value))
-        ctest_options.append(define('NP', spack.config.get('config:build_jobs')))
+            ctest_options.append(self.define('CTEST_DISABLE_OVERLAPPING_TESTS', True))
+            ctest_options.append(self.define('UNSET_TMPDIR_VAR', True))
+        ctest_options.append(self.define('CMAKE_CONFIGURE_ARGS',' '.join(v for v in cmake_options)))
+        ctest_options.append(self.define('HOST_NAME', spec.variants['host_name'].value))
+        ctest_options.append(self.define('EXTRA_BUILD_NAME', spec.variants['extra_name'].value))
+        ctest_options.append(self.define('NP', spack.config.get('config:build_jobs')))
         ctest_options.append('-VV')
         ctest_options.append('-S')
         ctest_options.append(os.path.join(self.stage.source_path,'reg_tests','CTestNightlyScript.cmake'))

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -11,6 +11,13 @@ from spack.pkg.builtin.kokkos import Kokkos
 import os
 from shutil import copyfile
 
+
+def trilinos_version_filter(name):
+    if 'develop' in name:
+        return name
+    else:
+        return 'stable'
+
 class NaluWind(bNaluWind, ROCmPackage):
     version('master', branch='master', submodules=True)
 
@@ -24,7 +31,7 @@ class NaluWind(bNaluWind, ROCmPackage):
     depends_on('trilinos gotype=long')
 
     for arch in ROCmPackage.amdgpu_targets:
-        depends_on('trilinos@stable: ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm~rocm_rdc amdgpu_target=%s' % arch, when='+rocm amdgpu_target=%s' % arch)
+        depends_on('trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm~rocm_rdc amdgpu_target=%s' % arch, when='+rocm amdgpu_target=%s' % arch)
         depends_on('hypre+rocm amdgpu_target=%s' % arch, when='+hypre+rocm amdgpu_target=%s' % arch)
 
     cxxstd=['14', '17']
@@ -35,7 +42,7 @@ class NaluWind(bNaluWind, ROCmPackage):
         depends_on('trilinos cxxstd=%s' % std, when='cxxstd=%s' % std)
 
     depends_on("ninja", type="build", when='+ninja')
-    
+
     @property
     def generator(self):
           if '+ninja' in self.spec:
@@ -78,7 +85,7 @@ class NaluWind(bNaluWind, ROCmPackage):
             spack_manager_local_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds')
             spack_manager_golds_dir = os.getenv('SPACK_MANAGER_GOLDS_DIR', default=spack_manager_local_golds)
             if '+snl' in spec:
-                spack_manager_golds_dir = '{}-{}'.format(spack_manager_golds_dir, spec['trilinos'].version)
+                spack_manager_golds_dir = '{}-{}'.format(spack_manager_golds_dir, trilinos_version_filter(spec['trilinos'].version))
 
             saved_golds = os.path.join(spack_manager_golds_dir, 'tmp', 'nalu-wind')
             current_golds = os.path.join(spack_manager_golds_dir, 'current', 'nalu-wind')

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -66,20 +66,19 @@ class NaluWind(bNaluWind, ROCmPackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
         cmake_options = super(NaluWind, self).cmake_args()
         cmake_options.append(self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'))
 
         if  spec.satisfies('dev_path=*'):
-            cmake_options.append(define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
-            cmake_options.append(define('ENABLE_TESTS', True))
+            cmake_options.append(self.define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
+            cmake_options.append(self.define('ENABLE_TESTS', True))
 
         if '+rocm' in self.spec:
             cmake_options.append('-DCMAKE_CXX_COMPILER={0}'.format(self.spec['hip'].hipcc))
-            cmake_options.append(define('ENABLE_ROCM', True))
+            cmake_options.append(self.define('ENABLE_ROCM', True))
 
         if spec['mpi'].name == 'openmpi':
-            cmake_options.append(define('MPIEXEC_PREFLAGS','--oversubscribe'))
+            cmake_options.append(self.define('MPIEXEC_PREFLAGS','--oversubscribe'))
 
         if spec.satisfies('+tests') or self.run_tests or spec.satisfies('dev_path=*'):
             spack_manager_local_golds = os.path.join(os.getenv('SPACK_MANAGER'), 'golds')
@@ -91,9 +90,9 @@ class NaluWind(bNaluWind, ROCmPackage):
             current_golds = os.path.join(spack_manager_golds_dir, 'current', 'nalu-wind')
             os.makedirs(saved_golds, exist_ok=True)
             os.makedirs(current_golds, exist_ok=True)
-            cmake_options.append(define('NALU_WIND_SAVE_GOLDS', True))
-            cmake_options.append(define('NALU_WIND_SAVED_GOLDS_DIR', saved_golds))
-            cmake_options.append(define('NALU_WIND_REFERENCE_GOLDS_DIR', current_golds))
+            cmake_options.append(self.define('NALU_WIND_SAVE_GOLDS', True))
+            cmake_options.append(self.define('NALU_WIND_SAVED_GOLDS_DIR', saved_golds))
+            cmake_options.append(self.define('NALU_WIND_REFERENCE_GOLDS_DIR', current_golds))
 
         return cmake_options
 

--- a/repos/exawind/packages/tioga/package.py
+++ b/repos/exawind/packages/tioga/package.py
@@ -17,11 +17,10 @@ class Tioga(bTioga):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
         options = super(Tioga, self).cmake_args()
 
         if 'dev_path' in spec:
-            options.append(define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
+            options.append(self.define('CMAKE_EXPORT_COMPILE_COMMANDS',True))
 
         return options
 

--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -64,13 +64,12 @@ class Trilinos(bTrilinos):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
         options = super(Trilinos, self).cmake_args()
 
         if '+stk' in spec:
             options.append(self.define_from_variant('STK_ENABLE_TESTS', 'stk_unit_tests'))
-            options.append(define('SEACAS_ENABLE_SEACASSupes', False))
-            options.append(define('Trilinos_ENABLE_SEACASSupes', False))
+            options.append(self.define('SEACAS_ENABLE_SEACASSupes', False))
+            options.append(self.define('Trilinos_ENABLE_SEACASSupes', False))
 
         if '+rocm' in self.spec:
             # Used as an optimization to only list the single specified

--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -10,8 +10,8 @@ from spack.pkg.builtin.trilinos import Trilinos as bTrilinos
 import os
 
 class Trilinos(bTrilinos):
-    # develop@6-5-2022
-    version('stable', commit='7498bcb9b0392c830b83787f3fb0c17079431f06')
+    version('13.4.0.2022.10.27', commit='da54d929ea62e78ba8e19c7d5aa83dc1e1f767c1')
+    version('13.2.0.2022.06.05', commit='7498bcb9b0392c830b83787f3fb0c17079431f06')
     variant('stk_unit_tests', default=False,
             description='turn on STK unit tests')
     variant('stk_simd', default=False,
@@ -22,13 +22,13 @@ class Trilinos(bTrilinos):
     patch('kokkos_zero_length_team.patch')
 
     depends_on("ninja", type="build", when='+ninja')
-   
+
     @property
     def generator(self):
           if '+ninja' in self.spec:
               return "Ninja"
           else:
-              return "Unix Makefiles" 
+              return "Unix Makefiles"
 
     def setup_build_environment(self, env):
         spec = self.spec


### PR DESCRIPTION
If a user already has `trilinos@stable` in it the `--reuse` will pick it up, but using `--fresh` will pick up the new "stable" version of trilinos