### PR TITLE
Automate gpu arch at the system level

### DIFF
--- a/configs/ascicgpu/packages.yaml
+++ b/configs/ascicgpu/packages.yaml
@@ -5,7 +5,7 @@ packages:
       mpi: [mpich]
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
-    variants: build_type=Release
+    variants: build_type=Release cuda_arch=70
     target: [x86_64]
   cmake:
     externals:

--- a/configs/crusher/packages.yaml
+++ b/configs/crusher/packages.yaml
@@ -106,3 +106,4 @@ packages:
       mpi: [cray-mpich@8.1.16]
       blas: [openblas]
       lapack: [openblas]
+    variants: amdgpu_targets=gfx90a

--- a/configs/eagle/packages.yaml
+++ b/configs/eagle/packages.yaml
@@ -38,3 +38,4 @@ packages:
     compiler: [gcc@9.3.0, clang@10.0.0, intel@20.0.2]
     providers:
       mpi: [mpt]
+    variants: cuda_arch=70

--- a/configs/spock/packages.yaml
+++ b/configs/spock/packages.yaml
@@ -125,3 +125,4 @@ packages:
       mpi: [cray-mpich@8.1.12]
       blas: [openblas]
       lapack: [openblas]
+    variants: amdgpu_target=gfx908

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -6,6 +6,7 @@ packages:
     providers:
       mpi:
         - spectrum-mpi@10.4
+    variants: cuda_arch=70 
   spectrum-mpi:
     version: [10.4]
     buildable: false

--- a/docs/user_profiles/developers/snapshot_workflow.md
+++ b/docs/user_profiles/developers/snapshot_workflow.md
@@ -34,10 +34,10 @@ We then activate Spack-Manager:
 Once Spack-Manager itself is activated, we create the Spack environment in which we will install and develop. 
 To do this we use the `spack manager create-env` command.
 Our environment will be called `exawind` using the `--name` argument. We will choose to focus on building Nalu-Wind using the spec
-`nalu-wind@master+hypre+cuda cuda_arch=70 %gcc`, which means, `nalu-wind` at the `master` branch, with hypre
-enabled (`+hypre`), and CUDA (`+cuda cuda_arch=70`), using the GCC compiler (`%gcc`, which without a version, selects the default compiler version).
+`nalu-wind@master+hypre+cuda  %gcc`, which means, `nalu-wind` at the `master` branch, with hypre
+enabled (`+hypre`), and CUDA (`+cuda `), using the GCC compiler (`%gcc`, which without a version, selects the default compiler version).
 ```
-[user@el1 user]$ spack manager create-env --name exawind --spec 'nalu-wind@master+hypre+cuda cuda_arch=70 %gcc'
+[user@el1 user]$ spack manager create-env --name exawind --spec 'nalu-wind@master+hypre+cuda  %gcc'
 making /scratch/user/spack-manager/environments/exawind
 ```
 
@@ -45,7 +45,7 @@ Once the environment is created, we need to activate it:
 ```
 [user@el1 user]$ spack env activate -d ${SPACK_MANAGER}/environments/exawind
 ```
-Both of the previous steps can be combined into one with `quick-create-env -n exawind -s 'nalu-wind@master+hypre+cuda cuda_arch=70%gcc'`.
+Both of the previous steps can be combined into one with `quick-create-env -n exawind -s 'nalu-wind@master+hypre+cuda %gcc'`.
 
 Next, we will turn `nalu-wind` and `hypre` into "develop specs" with a command that tells Spack we want to edit the code for these packages
 locally and always rebuild with our local clones of the packages. We do this with the `spack manager develop` command:
@@ -117,13 +117,13 @@ we have already set as develop specs.
 
 Once our externals and git clones are configured, we have the necessary `*.yaml` files in our `${SPACK_MANAGER}/environments/exawind` environment directory
 to "concretize" and (re)install our entire project. The `spack.yaml` file in this directory is the main yaml file in which the
-other yaml files are included. Concretizing is required to solve or map our loosely defined `nalu-wind@master+hypre+cuda cuda_arch=70 %gcc` spec into "concrete" parameters of our dependency graph (or DAG). The concrete DAG is _exactly_ how Spack will fulfill the dependencies for your spec. We
+other yaml files are included. Concretizing is required to solve or map our loosely defined `nalu-wind@master+hypre+cuda  %gcc` spec into "concrete" parameters of our dependency graph (or DAG). The concrete DAG is _exactly_ how Spack will fulfill the dependencies for your spec. We
 concretize with the command (we almost always want to use the force with `-f`). It will likely complain about us using the "original" concretizer, but this will be fixed in the future:
 ```
 [user@el1 user]$ spack concretize -f
 ==> Warning: the original concretizer is currently being used.
         Upgrade to "clingo" at your earliest convenience. The original concretizer will be removed from Spack starting at v0.18.0
-==> Concretized nalu-wind@master%gcc+cuda+hypre cuda_arch=70
+==> Concretized nalu-wind@master%gcc+cuda+hypre 
  -   rbzxf3n  nalu-wind@master%gcc@9.3.0~asan~boost~catalyst+cuda~fftw+hypre~ipo~openfast+pic~rocm+tests~tioga~wind-utils abs_tol=1e-15 build_type=Release cuda_arch=70 cxxstd=14 dev_path=/scratch/user/spack-manager/environments/exawind/nalu-wind rel_tol=1e-12 arch=linux-centos7-skylake_avx512
  -   b5pippu      ^cmake@3.22.1%gcc@9.3.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-centos7-skylake_avx512
  -   cwar5vn      ^cuda@11.2.2%gcc@9.3.0~allow-unsupported-compilers~dev arch=linux-centos7-skylake_avx512
@@ -190,7 +190,7 @@ We start by verifying our currently activated environment in Spack:
 ==> In environment /scratch/user/spack-manager/environments/exawind
 ==> Root specs
 -- no arch / gcc ------------------------------------------------
-nalu-wind@master%gcc +cuda+hypre cuda_arch=70
+nalu-wind@master%gcc +cuda+hypre 
 
 ==> 9 installed packages
 -- linux-centos7-skylake_avx512 / gcc@9.3.0 ---------------------

--- a/env-templates/exawind_ascicgpu_tests.yaml
+++ b/env-templates/exawind_ascicgpu_tests.yaml
@@ -5,13 +5,13 @@ spack:
     unify: false
   view: false
   specs:
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@stable~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@stable~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Debug ^trilinos@develop~uvm'
-    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda cuda_arch=70 %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@stable+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Debug ^trilinos@stable+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Debug ^trilinos@develop+uvm'
+    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@develop+uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@stable~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Debug ^trilinos@stable~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'
+    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0 build_type=Debug ^trilinos@develop~uvm'
+    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast+cuda %gcc@9.3.0 build_type=Release ^trilinos@develop~uvm'

--- a/env-templates/exawind_crusher.yaml
+++ b/env-templates/exawind_crusher.yaml
@@ -5,4 +5,4 @@ spack:
     unify: when_possible
   view: false
   specs:
-    - 'exawind+ninja~hypre+amr_wind_gpu~nalu_wind_gpu+rocm amdgpu_target=gfx90a ^nalu-wind+hypre ^amr-wind~hypre'
+    - 'exawind+ninja~hypre+amr_wind_gpu~nalu_wind_gpu+rocm ^nalu-wind+hypre ^amr-wind~hypre'

--- a/env-templates/exawind_eagle_tests.yaml
+++ b/env-templates/exawind_eagle_tests.yaml
@@ -5,5 +5,5 @@ spack:
     unify: when_possible
   view: false
   specs:
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda cuda_arch=70 %gcc@9.3.0'
-    - 'amr-wind-nightly +hypre+netcdf+cuda cuda_arch=70 %gcc@9.3.0'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0'
+    - 'amr-wind-nightly +hypre+netcdf+cuda %gcc@9.3.0'

--- a/env-templates/exawind_matrix.yaml
+++ b/env-templates/exawind_matrix.yaml
@@ -5,6 +5,6 @@ spack:
     unify: when_possible
   view: false
   specs:
-    - 'exawind+ninja+hypre+amr_wind_gpu+nalu_wind_gpu+cuda cuda_arch=70'
+    - 'exawind+ninja+hypre+amr_wind_gpu+nalu_wind_gpu+cuda '
     - 'exawind+ninja+hypre~amr_wind_gpu~nalu_wind_gpu~cuda'
-    - 'exawind+ninja~hypre+amr_wind_gpu~nalu_wind_gpu+cuda cuda_arch=70 ^nalu-wind+hypre ^amr-wind~hypre'
+    - 'exawind+ninja~hypre+amr_wind_gpu~nalu_wind_gpu+cuda  ^nalu-wind+hypre ^amr-wind~hypre'

--- a/env-templates/exawind_spock.yaml
+++ b/env-templates/exawind_spock.yaml
@@ -5,4 +5,4 @@ spack:
     unify: when_possible
   view: false
   specs:
-    - 'exawind~hypre+amr_wind_gpu~nalu_wind_gpu+rocm amdgpu_target=gfx908 ^nalu-wind+hypre ^amr-wind~hypre'
+    - 'exawind~hypre+amr_wind_gpu~nalu_wind_gpu+rocm ^nalu-wind+hypre ^amr-wind~hypre'


### PR DESCRIPTION
Older versions of spack required users to have to manually specify the gpu arch in every spec since `None` was a valid param.  Since adding conditional variants this constraint was removed and we can now configure it via `packages.yaml`.  Removing the arch requirement is one less thing our developers need to know to do gpu builds.