### PR TITLE
OpenFAST conditionally remove patch

### DIFF
--- a/repos/exawind/packages/openfast/package.py
+++ b/repos/exawind/packages/openfast/package.py
@@ -8,5 +8,5 @@
 from spack.pkg.builtin.openfast import Openfast as bOpenfast
 
 class Openfast(bOpenfast):
-    patch('hub_seg_fault.patch', when='@:3.2')
+    patch('hub_seg_fault.patch', when='@2.6:3.2')
     patch('segfault_message.patch', when='%clang@12.0.1 build_type=RelWithDebInfo')

--- a/repos/exawind/packages/openfast/package.py
+++ b/repos/exawind/packages/openfast/package.py
@@ -8,5 +8,5 @@
 from spack.pkg.builtin.openfast import Openfast as bOpenfast
 
 class Openfast(bOpenfast):
-    patch('hub_seg_fault.patch')
+    patch('hub_seg_fault.patch', when='@:3.2')
     patch('segfault_message.patch', when='%clang@12.0.1 build_type=RelWithDebInfo')


### PR DESCRIPTION
This should resolve the failing CI.  The patch was set to merge into OpenFAST@3.3.0: https://github.com/OpenFAST/openfast/pull/1227

That version was released 4 days ago: https://github.com/OpenFAST/openfast/releases/tag/v3.3.0