### PR TITLE
Fix type issue causing version comparisons

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -13,8 +13,9 @@ from shutil import copyfile
 
 
 def trilinos_version_filter(name):
-    if "develop" in name:
-        return name
+    local = str(name)
+    if "develop" in local:
+        return local
     else:
         return "stable"
 
@@ -85,6 +86,7 @@ class NaluWind(bNaluWind, ROCmPackage):
             spack_manager_golds_dir = os.getenv("SPACK_MANAGER_GOLDS_DIR", default=spack_manager_local_golds)
             if "+snl" in spec:
                 spack_manager_golds_dir = "{}-{}".format(spack_manager_golds_dir, trilinos_version_filter(spec["trilinos"].version))
+                exit()
 
             saved_golds = os.path.join(spack_manager_golds_dir, "tmp", "nalu-wind")
             current_golds = os.path.join(spack_manager_golds_dir, "current", "nalu-wind")

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -86,7 +86,6 @@ class NaluWind(bNaluWind, ROCmPackage):
             spack_manager_golds_dir = os.getenv("SPACK_MANAGER_GOLDS_DIR", default=spack_manager_local_golds)
             if "+snl" in spec:
                 spack_manager_golds_dir = "{}-{}".format(spack_manager_golds_dir, trilinos_version_filter(spec["trilinos"].version))
-                exit()
 
             saved_golds = os.path.join(spack_manager_golds_dir, "tmp", "nalu-wind")
             current_golds = os.path.join(spack_manager_golds_dir, "current", "nalu-wind")


### PR DESCRIPTION
Doing `v in version` is an overloaded operation for Spack Versions so we need to make sure the types are `string` for the comparison.

Closes #394 