### PR TITLE
Use latest trilinos when testing the Intel compiler at NREL

### DIFF
--- a/env-templates/exawind_rhodes_tests.yaml
+++ b/env-templates/exawind_rhodes_tests.yaml
@@ -5,12 +5,12 @@ spack:
     unify: when_possible
   view: false
   specs:
-    #- 'exawind-nightly +hypre+openfast %gcc@9.3.0'
-    #- 'exawind-nightly +hypre+openfast %intel@20.0.2'
-    #- 'exawind-nightly +hypre+openfast %clang@10.0.0'
+    - 'exawind-nightly +hypre+openfast %gcc@9.3.0'
+    - 'exawind-nightly +hypre+openfast %intel@20.0.2'
+    - 'exawind-nightly +hypre+openfast+asan ^amr-wind+asan build_type=Debug ^tioga+asan build_type=Debug ^trilinos+asan build_type=RelWithDebInfo %clang@10.0.0'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0'
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast cxxstd=14 %intel@20.0.2 ^trilinos@13.2.0.2022.06.05'
-    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+asan build_type=Debug %clang@10.0.0'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %intel@20.0.2'
+    - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+asan build_type=Debug ^tioga+asan build_type=Debug ^trilinos+asan build_type=RelWithDebInfo %clang@10.0.0'
     - 'amr-wind-nightly +hypre+masa+netcdf %gcc@9.3.0'
     - 'amr-wind-nightly +hypre+masa+netcdf %intel@20.0.2'
     - 'amr-wind-nightly +hypre+masa+netcdf+asan build_type=Debug %clang@10.0.0'

--- a/env-templates/exawind_rhodes_tests.yaml
+++ b/env-templates/exawind_rhodes_tests.yaml
@@ -7,7 +7,7 @@ spack:
   specs:
     - 'exawind-nightly +hypre+openfast %gcc@9.3.0'
     - 'exawind-nightly +hypre+openfast %intel@20.0.2'
-    - 'exawind-nightly +hypre+openfast+asan ^amr-wind+asan build_type=Debug ^tioga+asan build_type=Debug ^trilinos+asan build_type=RelWithDebInfo %clang@10.0.0'
+    - 'exawind-nightly +hypre+openfast+asan ^amr-wind+asan build_type=Debug ^nalu-wind+asan build_type=Debug ^tioga+asan build_type=Debug ^trilinos+asan build_type=RelWithDebInfo %clang@10.0.0'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %gcc@9.3.0'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast %intel@20.0.2'
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+asan build_type=Debug ^tioga+asan build_type=Debug ^trilinos+asan build_type=RelWithDebInfo %clang@10.0.0'

--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -18,6 +18,8 @@ class Trilinos(bTrilinos):
             description="Enable SIMD in STK")
     variant("ninja", default=False,
             description="Enable Ninja makefile generator")
+    variant("asan", default=False,
+            description="Turn on address sanitizer")
 
     patch("kokkos_zero_length_team.patch")
 
@@ -54,6 +56,10 @@ class Trilinos(bTrilinos):
                 env.append_flags("CXXFLAGS", "-DSTK_NO_BOOST_STACKTRACE")
                 if "~stk_simd" in spec:
                     env.append_flags("CXXFLAGS", "-DUSE_STK_SIMD_NONE")
+
+        if "+asan" in self.spec:
+            env.append_flags("CXXFLAGS", "-fsanitize=address -fno-omit-frame-pointer")
+            env.set("LSAN_OPTIONS", "suppressions={0}".format(join_path(self.package_dir, "sup.asan")))
 
     def setup_dependent_package(self, module, dependent_spec):
         if "+wrapper" in self.spec:

--- a/repos/exawind/packages/trilinos/sup.asan
+++ b/repos/exawind/packages/trilinos/sup.asan
@@ -1,0 +1,4 @@
+leak:libopen-pal
+leak:libmpi
+leak:libnetcdf
+leak:libc


### PR DESCRIPTION
Add asan variant to trilinos. Turn on asan for libraries in clang tests. Turn on exawind-driver nightly tests.