### PR TITLE
Don't use --reuse default when installing tests

### DIFF
--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -114,7 +114,7 @@ printf "\nActivating environment...\n"
 cmd "spack env activate -d ${EXAWIND_ENV_DIR}"
 
 printf "\nConcretizing environment...\n"
-cmd "spack concretize -f"
+cmd "spack concretize -f --fresh"
 
 # Develop spec stuff that isn't working as desired
 #DEVELOP_SPEC_DIR=${SPACK_MANAGER}/stage/develop-specs/amr-wind-nightly
@@ -135,7 +135,7 @@ printf "spack install \n"
 if [ "${SPACK_MANAGER_MACHINE}" == 'ascicgpu' ]; then
   time (spack install --keep-stage)
 else
-  time (for i in {1..4}; do spack install --keep-stage & done; wait)
+  time (for i in {1..4}; do spack install --keep-stage --fresh & done; wait)
 fi
 printf "\nTests ended at: $(date)\n"
 


### PR DESCRIPTION
I'm seeing reuse happening in the tests and breaking some things for me. Hoping this would be the fix.