### PR TITLE
Build HDF5 on Summit instead of use it as an external so OpenFAST can find it

### DIFF
--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -28,13 +28,6 @@ packages:
       #- spec: "cuda@11.0.3%gcc"
       #  modules:
       #    - cuda/11.0.3
-  hdf5:
-    version: [1.10.7]
-    buildable: false
-    externals:
-      - spec: "hdf5@1.10.7%gcc"
-        modules:
-          - hdf5/1.10.7
   netcdf-c:
     version: [4.8.1]
     buildable: false


### PR DESCRIPTION
I think this is the solution. Currently testing it.

edit: Seems to work.