### PR TITLE
Constrain stk-coupling-versions-func-overload.patch for trilinos

### DIFF
--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -27,7 +27,7 @@ class Trilinos(bTrilinos):
 
     machine = find_machine(verbose=False, full_machine_name=False)
     if machine == "eagle":
-        patch("stk-coupling-versions-func-overload.patch")
+        patch("stk-coupling-versions-func-overload.patch", when="@13.3.0:")
 
     depends_on("ninja", type="build", when="+ninja")
 


### PR DESCRIPTION
For versions greater than 13.2.