### PR TITLE
Require older versions of perl in base and rhodes configs

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -18,6 +18,8 @@ packages:
   parallel-netcdf:
     version: [1.12.2]
     variants: ~fortran
+  perl:
+    require: "@5.34.1"
   tioga:
     version: [develop]
   hypre:

--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -20,6 +20,8 @@ packages:
     variants: ~fortran
   perl:
     require: "@5.34.1"
+  python:
+    require: "@3.9.15"
   tioga:
     version: [develop]
   hypre:

--- a/configs/rhodes/packages.yaml
+++ b/configs/rhodes/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   perl:
-    version: [5.32.0]
+    require: "@5.32.0"
   all:
     compiler: [gcc@9.3.0, clang@10.0.0, intel@20.0.2]
     providers:

--- a/configs/spock/packages.yaml
+++ b/configs/spock/packages.yaml
@@ -86,7 +86,7 @@ packages:
         modules:
           - zlib/1.2.11
   perl:
-    version: [5.34.0]
+    require: "@5.34.0"
     buildable: false
     externals:
       - spec: perl@5.34.0

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -110,7 +110,7 @@ packages:
       - spec: "pkgconf@1.4.2%gcc"
         prefix: /usr/
   python:
-    version: [3.7.7]
+    require: "@3.7.7"
     buildable: false
     externals:
       - spec: "python@3.7.7%gcc"


### PR DESCRIPTION
Latest perl fails to build like has happened so many times in the past.