### PR TITLE
Require latest mpich on rhodes

### DIFF
--- a/configs/rhodes/packages.yaml
+++ b/configs/rhodes/packages.yaml
@@ -1,4 +1,6 @@
 packages:
+  mpich:
+    require: "@4.0.2"
   perl:
     require: "@5.32.0"
   all:


### PR DESCRIPTION
I don't know why it decides to use 3.4.3 sometimes. Still not a fan of the new concretizer.