### PR TITLE
Use require in configs to force certain versions of packages

### DIFF
--- a/configs/arcticus/packages.yaml
+++ b/configs/arcticus/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   boost:
-    version: [1.78.0]
+    require: "@1.78.0"
     variants: ~shared+pic
   all:
     compiler: [intel]

--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -4,31 +4,31 @@ packages:
   conduit:
     variants: ~fortran~hdf5_compat
   boost:
-    version: [1.76.0]
+    require: "@1.76.0"
     variants: cxxstd=17
   hdf5:
-    version: [1.10.7]
+    require: "@1.10.7"
     variants: +cxx+hl
   netcdf-c:
-    version: [4.7.4]
+    require: "@4.7.4"
     variants: +parallel-netcdf maxdims=65536 maxvars=524288
   openfast:
-    version: [master]
+    require: "@master"
     variants: +cxx
   parallel-netcdf:
-    version: [1.12.2]
+    require: "@1.12.2"
     variants: ~fortran
   perl:
     require: "@5.34.1"
   python:
     require: "@3.9.15"
   tioga:
-    version: [develop]
+    require: "@develop"
   hypre:
-    version: [develop]
+    require: "@develop"
     variants: ~fortran
   yaml-cpp:
-    version: [0.6.3]
+    require: "@0.6.3"
   trilinos:
     version: [13.4.0.2022.10.27, develop]
     variants: ~adios2~alloptpkgs~amesos+amesos2~anasazi~aztec+belos+boost~chaco~complex~debug~dtk~epetra~epetraext+exodus+explicit_template_instantiation~float~fortran~fortrilinos+glm+gtest+hdf5~hypre~ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos~mesquite+metis~minitensor~ml+mpi+muelu~mumps~nox~openmp~phalanx~piro~python~rol~rythmos~sacado+shards~shylu+stk~stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+uvm~x11~xsdkflags+zlib+zoltan+zoltan2 gotype=long cxxstd=14 build_type=Release

--- a/configs/eagle/packages.yaml
+++ b/configs/eagle/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   perl:
-    version: [5.32.0]
+    require: "@5.32.0"
   slurm:
     buildable: false
     externals:
@@ -10,7 +10,7 @@ packages:
         - slurm
   cuda:
     buildable: false
-    version: [11.2.2]
+    require: "@11.2.2"
     externals:
     - spec: cuda@11.2.2
       prefix: /nopt/nrel/ecom/hpacf/compilers/2020-07/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.4.0/cuda-11.2.2-5muy3vijyqputqmbdyzhltqot3fvwibu
@@ -26,7 +26,7 @@ packages:
     variants: +optimizations+gdrcopy
     version: [1.8.1]
   mpt:
-    version: [2.22]
+    require: "@2.22"
     buildable: false
     externals:
     - spec: mpt@2.22

--- a/configs/ellis/packages.yaml
+++ b/configs/ellis/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   cuda:
     buildable: false
-    version: [11.4.4]
+    require: "@11.4.4"
     externals:
     - spec: cuda@11.4.4
       prefix: /projects/hpacf/apps/compilers/2022-10/spack/opt/spack/linux-rocky8-zen/gcc-8.5.0/cuda-11.4.4-gzsu4bitcwa6ovuw5c32n2vgol3vbxbt

--- a/configs/spock/packages.yaml
+++ b/configs/spock/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   cray-mpich:
-    version: [8.1.12]
+    require: "@8.1.12"
     buildable: false
     externals:
       - spec: "cray-mpich@8.1.12%gcc@9.3.0"
@@ -22,7 +22,7 @@ packages:
           - libfabric/1.11.0.4.75
           - craype-network-ofi
   hip:
-    version: [5.0.0]
+    require: "@5.0.0"
     buildable: false
     externals:
       - spec: hip@5.0.0
@@ -30,7 +30,7 @@ packages:
         modules:
           - craype-accel-amd-gfx908
   hsa-rocr-dev:
-    version: [5.0.0]
+    require: "@5.0.0"
     buildable: false
     externals:
       - spec: hsa-rocr-dev@5.0.0
@@ -38,7 +38,7 @@ packages:
         modules:
           - craype-accel-amd-gfx908
   llvm-amdgpu:
-    version: [5.0.0]
+    require: "@5.0.0"
     buildable: false
     externals:
       - spec: llvm-amdgpu@5.0.0
@@ -46,7 +46,7 @@ packages:
         modules:
           - craype-accel-amd-gfx908
   boost:
-    version: [1.73.0]
+    require: "@1.73.0"
     buildable: false
     externals:
       - spec: boost@1.73.0
@@ -70,7 +70,7 @@ packages:
 #        modules:
 #          - cray-parallel-netcdf/1.12.1.7
   cmake:
-    version: [3.22.1]
+    require: "@3.22.1"
     buildable: false
     externals:
       - spec: cmake@3.22.1
@@ -78,7 +78,7 @@ packages:
         modules:
           - cmake/3.22.1
   zlib:
-    version: [1.2.11]
+    require: "@1.2.11"
     buildable: false
     externals:
       - spec: zlib@1.2.11
@@ -94,7 +94,7 @@ packages:
         modules:
           - perl/5.34.0
   openblas:
-    version: [0.3.17]
+    require: "@0.3.17"
     buildable: false
     externals:
       - spec: openblas@0.3.17
@@ -102,7 +102,7 @@ packages:
         modules:
           - openblas/0.3.17
   xz:
-    version: [5.2.5]
+    require: "@5.2.5"
     buildable: false
     externals:
       - spec: xz@5.2.5
@@ -110,7 +110,7 @@ packages:
         modules:
           - xz/5.2.5
   libxml2:
-    version: [2.9.10]
+    require: "@2.9.10"
     buildable: false
     externals:
       - spec: libxml2@2.9.10

--- a/configs/summit/packages.yaml
+++ b/configs/summit/packages.yaml
@@ -8,7 +8,7 @@ packages:
         - spectrum-mpi@10.4
     variants: cuda_arch=70 
   spectrum-mpi:
-    version: [10.4]
+    require: "@10.4"
     buildable: false
     externals:
       - spec: "spectrum-mpi@10.4%gcc@10.2.0"
@@ -16,7 +16,7 @@ packages:
           - gcc/10.2.0
           - spectrum-mpi/10.4.0.3-20210112
   cuda:
-    version: [11.4.2]
+    require: "@11.4.2"
     buildable: false
     externals:
       - spec: "cuda@11.4.2%gcc"
@@ -29,82 +29,82 @@ packages:
       #  modules:
       #    - cuda/11.0.3
   netcdf-c:
-    version: [4.8.1]
+    require: "@4.8.1"
     buildable: false
     externals:
       - spec: "netcdf-c@4.8.1%gcc"
         modules:
           - netcdf-c/4.8.1
   parallel-netcdf:
-    version: [1.12.2]
+    require: "@1.12.2"
     buildable: false
     externals:
       - spec: "parallel-netcdf@1.12.2%gcc"
         modules:
           - parallel-netcdf/1.12.2
   cmake:
-    version: [3.21.3]
+    require: "@3.21.3"
     buildable: false
     externals:
       - spec: "cmake@3.21.3%gcc"
         modules:
           - cmake/3.21.3
   zlib:
-    version: [1.2.11]
+    require: "@1.2.11"
     buildable: false
     externals:
       - spec: "zlib@1.2.11%gcc"
         modules:
           - zlib/1.2.11
   bzip2:
-    version: [1.0.6]
+    require: "@1.0.6"
     buildable: false
     externals:
       - spec: "bzip2@1.0.6%gcc"
         prefix: /usr/
   libxml2:
-    version: [2.9.10]
+    require: "@2.9.10"
     buildable: false
     externals:
       - spec: "libxml2@2.9.10%gcc"
         modules:
           - libxml2/2.9.10
   m4:
-    version: [1.4.18]
+    require: "@1.4.18"
     buildable: false
     externals:
       - spec: "m4@1.4.18%gcc"
         prefix: /usr/
   perl:
-    version: [5.26.2]
+    require: "@5.26.2"
     buildable: false
     externals:
       - spec: "perl@5.26.2%gcc"
         modules:
           - perl/5.26.2
   libtool:
-    version: [2.4.2]
+    require: "@2.4.2"
     buildable: false
     externals:
       - spec: "libtool@2.4.2%gcc"
         modules:
           - libtool/2.4.2
   autoconf:
-    version: [2.69]
+    require: "@2.69"
     buildable: false
     externals:
       - spec: "autoconf@2.69%gcc"
         modules:
           - autoconf/2.69
   automake:
-    version: [1.16.1]
+    require: "@1.16.1"
     buildable: false
     externals:
       - spec: "automake@1.16.1%gcc"
         modules:
           - automake/1.16.1
   pkgconf:
-    version: [1.4.2]
+    require: "@1.4.2"
     buildable: false
     externals:
       - spec: "pkgconf@1.4.2%gcc"
@@ -117,33 +117,33 @@ packages:
         modules:
           - python/3.7.7
   netlib-lapack:
-    version: [3.9.1]
+    require: "@3.9.1"
     buildable: false
     externals:
       - spec: "netlib-lapack@3.9.1%gcc"
         modules:
           - netlib-lapack/3.9.1
   ncurses:
-    version: [6.2]
+    require: "@6.2"
     buildable: false
     externals:
       - spec: "ncurses@6.2%gcc"
         prefix: /usr/
   openssl:
-    version: [1.1.1l]
+    require: "@1.1.1l"
     buildable: false
     externals:
       - spec: "openssl@1.1.1l%gcc"
         prefix: /usr/
   boost:
-    version: [1.76.0]
+    require: "@1.76.0"
     buildable: false
     externals:
       - spec: "boost@1.76.0%gcc"
         modules:
           - boost/1.76.0
   umpire:
-    version: [6.0.0]
+    require: "@6.0.0"
     buildable: false
     externals:
       - spec: "umpire@6.0.0-no_omp-shared%gcc"


### PR DESCRIPTION
It seems like "preferences" don't matter with the new concretizer and requires is required if you want to guarantee certain package versions so I think we need to use that instead.