### PR TITLE
Allow users to make install_tree local to env

### DIFF
--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -81,7 +81,6 @@ def create_env(parser, args):
         else:
             yaml["spack"]["config"] = {"install_tree": {"root": "$env/opt"}}
 
-
     inc_creator = IncludesCreator()
     genPath = os.path.join(os.environ["SPACK_MANAGER"], "configs", "base")
     inc_creator.add_scope("base", genPath)
@@ -141,7 +140,7 @@ def setup_parser_args(sub_parser):
         action="store_true",
         required=False,
         help="Move install tree inside the environment directory. This will divorce all the "
-             "installations from the rest of the spack database"
+        "installations from the rest of the spack database",
     )
 
 

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -75,6 +75,13 @@ def create_env(parser, args):
         for s in spec_list:
             env.add(s)
 
+    if args.local_source:
+        if "config" in yaml["spack"]:
+            yaml["spack"]["config"]["install_tree"] = {"root": "$env/opt"}
+        else:
+            yaml["spack"]["config"] = {"install_tree": {"root": "$env/opt"}}
+
+
     inc_creator = IncludesCreator()
     genPath = os.path.join(os.environ["SPACK_MANAGER"], "configs", "base")
     inc_creator.add_scope("base", genPath)
@@ -127,6 +134,14 @@ def setup_parser_args(sub_parser):
         default=[],
         nargs="+",
         help="Specs to populate the environment with",
+    )
+    sub_parser.add_argument(
+        "-l",
+        "--local-source",
+        action="store_true",
+        required=False,
+        help="Move install tree inside the environment directory. This will divorce all the "
+             "installations from the rest of the spack database"
     )
 
 

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -157,3 +157,10 @@ spack:
         manager("create-env", "-y", "template.yaml")
         e = env.Environment(tmpdir.strpath)
         assert "when_possible" == e.yaml["spack"]["concretizer"]["unify"]
+
+
+def test_local_source_tree_can_be_added_to_env(tmpdir):
+    with tmpdir.as_cwd():
+        manager("create-env", "-s", "nalu-wind", "-l")
+        e = env.Environment(tmpdir.strpath)
+        assert "$env/opt" in e.yaml["spack"]["config"]["install_tree"]["root"]


### PR DESCRIPTION
This is a convenience feature that I was working on as a part of snapshots but I think could be useful for all environment creation. It allows an automated way to set the install_tree:root inside the environment.  This will help with book keeping for space conscientious users.

This could also be helpful with nightly testing at some point.