### PR TITLE
Add an option for user configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp
 views
 modules
 cache
+configs/user
 # file types
 __pycache__
 *.lock

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -79,11 +79,14 @@ def create_env(parser, args):
     genPath = os.path.join(os.environ["SPACK_MANAGER"], "configs", "base")
     inc_creator.add_scope("base", genPath)
     hostPath = os.path.join(os.environ["SPACK_MANAGER"], "configs", machine)
+    userPath = os.path.join(os.environ["SPACK_MANAGER"], "configs", "user")
 
     if os.path.exists(hostPath):
         inc_creator.add_scope("machine", hostPath)
     else:
         print("Host not setup in spack-manager: %s" % hostPath)
+    if os.path.exists(userPath):
+        inc_creator.add_scope("machine", userPath)
 
     include_file_name = "include.yaml"
     include_file = os.path.join(theDir, include_file_name)

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -86,7 +86,7 @@ def create_env(parser, args):
     else:
         print("Host not setup in spack-manager: %s" % hostPath)
     if os.path.exists(userPath):
-        inc_creator.add_scope("machine", userPath)
+        inc_creator.add_scope("sm_user", userPath)
 
     include_file_name = "include.yaml"
     include_file = os.path.join(theDir, include_file_name)


### PR DESCRIPTION
Give users the option to add their own specific configs to spack-manager with a $SPACK_MANAGER/configs/user directory that will glob configs into the `includes.yaml` for spack-manager created environments