### PR TITLE
Turn off shared libs for nalu-wind when using cuda

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -30,6 +30,8 @@ class NaluWind(bNaluWind, ROCmPackage):
             description="Enable Ninja makefile generator")
     variant("shared", default=True,
             description="Build shared libraries")
+    conflict("+shared", when="+cuda",
+             msg="invalid device functions are generated with shared libs and cuda")
 
     depends_on("trilinos gotype=long")
 

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -30,7 +30,7 @@ class NaluWind(bNaluWind, ROCmPackage):
             description="Enable Ninja makefile generator")
     variant("shared", default=True,
             description="Build shared libraries")
-    conflict("+shared", when="+cuda",
+    conflicts("+shared", when="+cuda",
              msg="invalid device functions are generated with shared libs and cuda")
 
     depends_on("trilinos gotype=long")


### PR DESCRIPTION
I ran some tests today to investigate the dashboard failures.  
`+shared`
```console
ctest -R unit -VV
UpdateCTestConfiguration  from :/scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-o5sth6g/DartConfiguration.tcl
 Add coverage exclude regular expressions.
UpdateCTestConfiguration  from :/scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-o5sth6g/DartConfiguration.tcl
Test project /scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-o5sth6g
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 8
    Start 8: unitTestGPU

8: Test command: /usr/bin/sh "-c" "/projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/bin/mpiexec -n 1  /scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-o5sth6g/unittestX  --gtest_filter=BasicKokkos.discover_execution_space:*.NGP*"
8: Test timeout computed to be: 20000
8: terminate called after throwing an instance of 'std::runtime_error'
8:   what():  cudaDeviceSynchronize() error( cudaErrorInvalidSource): device kernel image is invalid /scratch/psakiev/spack-manager/environments/cuda-fix/trilinos/packages/kokkos/core/src/Cuda/Kokkos_Cuda_Instance.cpp:161
8: 
8: ===================================================================================
8: =   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
8: =   PID 45643 RUNNING AT ascicgpu22
8: =   EXIT CODE: 6
8: =   CLEANING UP REMAINING PROCESSES
8: =   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
8: ===================================================================================
8: YOUR APPLICATION TERMINATED WITH THE EXIT STRING: Aborted (signal 6)
8: This typically refers to a problem with your application.
8: Please see the FAQ page for debugging suggestions
1/1 Test #8: unitTestGPU ......................***Failed    4.47 sec
```
`~shared`
```console
ctest -R unit -VV
UpdateCTestConfiguration  from :/scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-e65fhjk/DartConfiguration.tcl
 Add coverage exclude regular expressions.
UpdateCTestConfiguration  from :/scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-e65fhjk/DartConfiguration.tcl
Test project /scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-e65fhjk
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 8
    Start 8: unitTestGPU

8: Test command: /usr/bin/sh "-c" "/projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/bin/mpiexec -n 1  /scratch/psakiev/spack-manager/environments/cuda-fix/nalu-wind/spack-build-e65fhjk/unittestX  --gtest_filter=BasicKokkos.discover_execution_space:*.NGP*"
8: Test timeout computed to be: 20000
8:    Nalu-Wind Version: v1.3.0-180-g40b05d62
8:    Nalu-Wind GIT Commit SHA: 40b05d62cba2a2e153a87f26af7efabbb1872708-DIRTY
8:    Trilinos Version: 13.5-gda54d929ea6
8: 
8: Note: Google Test filter = BasicKokkos.discover_execution_space:*.NGP*
8: [==========] Running 149 tests from 35 test suites.
8: [----------] Global test environment set-up.
8: [----------] 1 test from BasicKokkos
8: [ RUN      ] BasicKokkos.discover_execution_space
8: 
8: Kokkos::Cuda is available.
8: Default execution space info: Device Execution Space:
8:   KOKKOS_ENABLE_CUDA: yes
8: Cuda Atomics:
8:   KOKKOS_ENABLE_CUDA_ATOMICS: no
8: Cuda Options:
8:   KOKKOS_ENABLE_CUDA_LAMBDA: yes
8:   KOKKOS_ENABLE_CUDA_LDG_INTRINSIC: yes
8:   KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE: yes
8:   KOKKOS_ENABLE_CUDA_UVM: yes
8:   KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA: yes
8: 
8: Cuda Runtime Configuration:
8: macro  KOKKOS_ENABLE_CUDA      : defined
8: macro  CUDA_VERSION          = 11020 = version 11.2
8: Kokkos::Cuda[ 0 ] Tesla V100-PCIE-32GB capability 7.0, Total Global Memory: 31.75 G, Shared Memory per Block: 48 K : Selected
8: Kokkos::Cuda[ 1 ] Tesla V100-PCIE-32GB capability 7.0, Total Global Memory: 31.75 G, Shared Memory per Block: 48 K
8: Kokkos::Cuda[ 2 ] Tesla V100-PCIE-32GB capability 7.0, Total Global Memory: 31.75 G, Shared Memory per Block: 48 K
8: Kokkos::Cuda[ 3 ] Tesla V100-PCIE-32GB capability 7.0, Total Global Memory: 31.75 G, Shared Memory per Block: 48 K
8: 
8: [       OK ] BasicKokkos.discover_execution_space (0 ms)
8: [----------] 1 test from BasicKokkos (0 ms total)
8: 
8: [----------] 9 tests from Hex8MeshWithNSOFields
8: [ RUN      ] Hex8MeshWithNSOFields.NGPElemDataRequests
8: [       OK ] Hex8MeshWithNSOFields.NGPElemDataRequests (3 ms)
8: [ RUN      ] Hex8MeshWithNSOFields.NGPMeshField
8: [       OK ] Hex8MeshWithNSOFields.NGPMeshField (5 ms)
8: [ RUN      ] Hex8MeshWithNSOFields.NGPScratchViews
8: [       OK ] Hex8MeshWithNSOFields.NGPScratchViews (8 ms)
8: [ RUN      ] Hex8MeshWithNSOFields.NGPAssembleElemSolver
[...]
8: [----------] Global test environment tear-down
8: [==========] 149 tests from 35 test suites ran. (1180 ms total)
8: [  PASSED  ] 149 tests.
1/1 Test #8: unitTestGPU ......................   Passed   10.54 sec
```