### PR TITLE
Update bootstrap location and config path

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -10,15 +10,17 @@
 
 if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   export SPACK_ROOT=${SPACK_MANAGER}/spack
-  export SPACK_DISABLE_LOCAL_CONFIG=true
   export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
-  export SPACK_USER_CONFIG_PATH=${SPACK_MANAGER}/.config
+  export SPACK_USER_CONFIG_PATH=${SPACK_MANAGER}/.spack
   export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd:${SPACK_MANAGER}/spack-scripting/scripting
   source ${SPACK_ROOT}/share/spack/setup-env.sh
 
   # Clean Spack misc caches
   # Put this back in if outdated caches directory still causes problems when updating Spack submodule
   #spack clean -m
+  
+  # move the bootstrap store outside the user config path
+  spack bootstrap root ${SPACK_MANAGER}/.bootstrap
 
   if [[ -z $(spack config --scope site blame config | grep spack-scripting) ]]; then
     spack config --scope site add "config:extensions:[${SPACK_MANAGER}/spack-scripting]"

--- a/start.sh
+++ b/start.sh
@@ -196,7 +196,10 @@ function sm-clean(){
   echo "Remove user cache of configs:"
   cmd "rm -rf ~/.spack"
   echo "Remove Spack-Manager cache:"
+  # leave for legacy purposes
   cmd "rm -rf ${SPACK_MANAGER}/.cache"
+  # new config path
+  cmd "rm -rf ${SPACK_MANAGER}/.spack"
   echo "Use the native Spack clean system":
   cmd "spack clean --all"
   echo "Cleaning out pycache from spack-manager repos:"


### PR DESCRIPTION
Update a few things about the spack configs to make them more useful:

1) Remove the `SPACK_DISABLE_USER_CONFIG` constraint.  Setting it and `SPACK_USER_CONFIG_PATH` don't make sense since it removes the need for this command.  Further more the `SPACK_USER_CONFIG_PATH` can be used to auto populate configs through some interesting magic as shown in #437. 

2) Set `SPACK_USER_CONFIG_PATH` to be `${SPACK_MANAGER}/.spack` so it is more aligned with spack terminology/thinking
 
3) Move the bootstrap store to `${SPACK_MANAGER}/.bootstrap` so it is no longer blown away when `sm-clean` is run.