### PR TITLE
AMD Compiler Flags 

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -34,6 +34,8 @@ class NaluWind(bNaluWind, ROCmPackage):
              msg="invalid device functions are generated with shared libs and cuda")
     conflicts("+shared", when="+rocm",
              msg="invalid device functions are generated with shared libs and rocm")
+    conflicts("+cuda", when="+rocm")
+    conflicts("+rocm", when="+cuda")
 
     depends_on("trilinos gotype=long")
 
@@ -72,7 +74,7 @@ class NaluWind(bNaluWind, ROCmPackage):
             env.set("MPICH_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set("MPICXX_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
         if "+rocm" in self.spec:
-            env.append_flags("CXXFLAGS", "-fgpu-rdc")
+            env.append_flags('CXXFLAGS', '--gpu-max-threads-per-block=128 -fgpu-rdc')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This resolves the unhandled Spill compile errors. We can now build with debug symbols.
