### PR TITLE
remove SNL clang/intel nightly testing specs for now

### DIFF
--- a/env-templates/exawind_cee_tests.yaml
+++ b/env-templates/exawind_cee_tests.yaml
@@ -3,14 +3,15 @@ spack:
   # CPU tests run on ascic
   - nalus:
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@10.3.0 build_type=Release ^trilinos@13.4.0.2022.10.27'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@13.4.0.2022.10.27'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@13.0.1 build_type=Release ^trilinos@13.4.0.2022.10.27'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@13.0.1 build_type=Debug ^trilinos@13.4.0.2022.10.27'
     - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %gcc@10.3.0 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@13.0.1 build_type=Release ^trilinos@develop'
-    - 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@13.0.1 build_type=Debug ^trilinos@develop'
-    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast %clang@13.0.1 build_type=Release ^trilinos@develop'
+    - 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast %gcc@10.3.0 build_type=Release ^trilinos@develop'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@13.4.0.2022.10.27'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@13.0.1 build_type=Release ^trilinos@13.4.0.2022.10.27'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@13.0.1 build_type=Debug ^trilinos@13.4.0.2022.10.27'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %intel@2021.1.2 build_type=Release ^trilinos@develop'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast %clang@13.0.1 build_type=Release ^trilinos@develop'
+      #- 'nalu-wind-nightly+snl +fftw+tioga+hypre+openfast+asan %clang@13.0.1 build_type=Debug ^trilinos@develop'
+      #- 'nalu-wind-nightly+snl ~fftw~tioga~hypre~openfast %clang@13.0.1 build_type=Release ^trilinos@develop'
     when: '"gpu" not in hostname'
   # GPU tests run on ascicgpu
   - nalus:


### PR DESCRIPTION
added a gcc line without the optional TPLs (previously we relied on clang for this testing)