### PR TITLE
Remove redundant call to set bootstrap store dir

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -20,7 +20,7 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   #spack clean -m
   
   # move the bootstrap store outside the user config path
-  if [[ -z $(spack config --scope site blame bootstrap | grep "root: ${SPACK_MANAGER}/.bootstrap") ]]; then
+  if [[ -z $(spack config blame bootstrap | grep "root: ${SPACK_MANAGER}/.bootstrap") ]]; then
     spack bootstrap root ${SPACK_MANAGER}/.bootstrap
   fi
 

--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -20,7 +20,9 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   #spack clean -m
   
   # move the bootstrap store outside the user config path
-  spack bootstrap root ${SPACK_MANAGER}/.bootstrap
+  if [[ -z $(spack config --scope site blame config | grep .smbootstrap) ]]; then
+    spack bootstrap root ${SPACK_MANAGER}/.smbootstrap
+  fi
 
   if [[ -z $(spack config --scope site blame config | grep spack-scripting) ]]; then
     spack config --scope site add "config:extensions:[${SPACK_MANAGER}/spack-scripting]"

--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -20,8 +20,8 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   #spack clean -m
   
   # move the bootstrap store outside the user config path
-  if [[ -z $(spack config --scope site blame config | grep .smbootstrap) ]]; then
-    spack bootstrap root ${SPACK_MANAGER}/.smbootstrap
+  if [[ -z $(spack config --scope site blame bootstrap | grep "root: ${SPACK_MANAGER}/.bootstrap") ]]; then
+    spack bootstrap root ${SPACK_MANAGER}/.bootstrap
   fi
 
   if [[ -z $(spack config --scope site blame config | grep spack-scripting) ]]; then


### PR DESCRIPTION
We are currently calling the command to set the bootstrap store too much It leads to an unnecessary line every time the users run `spack-start`