### PR TITLE
Force use of openmpi on cee tests

### DIFF
--- a/env-templates/exawind_cee_tests.yaml
+++ b/env-templates/exawind_cee_tests.yaml
@@ -30,6 +30,9 @@ spack:
   - include.yaml
   concretizer:
     unify: false
+  packages:
+    mpi:
+      require: 'openmpi'
   view: false
   specs:
   - $nalus


### PR DESCRIPTION
Tests have started to pick up `mvpachi2` as the mpi for some reason. I'm not sure why, but `mvapich2` was added for testing and demo's. It has not been configured yet so we should only be using `openmpi`.  This forces the use of `openmpi` on the cee tests