### PR TITLE
Update crusher configuration

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -4,31 +4,31 @@ packages:
   conduit:
     variants: ~fortran~hdf5_compat
   boost:
-    version: [1.76.0]
+    require: "@1.76.0"
     variants: cxxstd=17
   hdf5:
-    version: [1.10.7]
+    require: "@1.12.1"
     variants: +cxx+hl
   netcdf-c:
-    version: [4.7.4]
+    require: "@4.7.4"
     variants: +parallel-netcdf maxdims=65536 maxvars=524288
   openfast:
-    version: [master]
+    require: "@master"
     variants: +cxx
   parallel-netcdf:
-    version: [1.12.2]
+    require: "@1.12.2"
     variants: ~fortran
   perl:
     require: "@5.34.1"
   python:
     require: "@3.9.15"
   tioga:
-    version: [develop]
+    require: "@develop"
   hypre:
-    version: [develop]
+    require: "@develop"
     variants: ~fortran
   yaml-cpp:
-    version: [0.6.3]
+    require: "@0.6.3"
   trilinos:
     version: [13.4.0.2022.10.27, develop]
     variants: ~adios2~alloptpkgs~amesos+amesos2~anasazi~aztec+belos+boost~chaco~complex~debug~dtk~epetra~epetraext+exodus+explicit_template_instantiation~float~fortran~fortrilinos+glm+gtest+hdf5~hypre~ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos~mesquite+metis~minitensor~ml+mpi+muelu~mumps~nox~openmp~phalanx~piro~python~rol~rythmos~sacado+shards~shylu+stk~stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+uvm~x11~xsdkflags+zlib+zoltan+zoltan2 gotype=long cxxstd=14 build_type=Release

--- a/configs/crusher/compilers.yaml
+++ b/configs/crusher/compilers.yaml
@@ -1,6 +1,6 @@
 compilers:
   - compiler:
-      spec: clang@14.0.0
+      spec: cce@14.0.2
       paths:
         cc: cc
         cxx: CC
@@ -10,9 +10,14 @@ compilers:
       operating_system: sles15
       target: any
       modules:
-      - PrgEnv-amd/8.3.3
+      - PrgEnv-cray/8.3.3
+      - cce/14.0.2
       - rocm/5.2.0
+      - craype/2.7.16
       - libfabric
+      - xpmem
       - craype-x86-trento
-      environment: {}
+      environment:
+        prepend_path:
+          PKG_CONFIG_PATH: /opt/cray/xpmem/2.4.4-2.3_11.2__gff0e1d9.shasta/lib64/pkgconfig
       extra_rpaths: []

--- a/configs/crusher/packages.yaml
+++ b/configs/crusher/packages.yaml
@@ -1,15 +1,15 @@
 packages:
   cray-mpich:
-    version: [8.1.17]
+    require: "@8.1.17"
     buildable: false
     externals:
-      - spec: "cray-mpich@8.1.17%clang@14.0.0"
-        prefix: /opt/cray/pe/mpich/8.1.17/ofi/amd/5.0
+      - spec: "cray-mpich@8.1.17%cce@14.0.2"
+        prefix: /opt/cray/pe/mpich/8.1.17/ofi/cray/10.0
         modules:
           - cray-mpich/8.1.17
           - craype-network-ofi
   rocprim:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: rocprim@5.2.0
@@ -18,7 +18,7 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   rocrand:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: rocrand@5.2.0
@@ -27,7 +27,7 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   rocthrust:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: rocthrust@5.2.0
@@ -36,7 +36,7 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   rocsparse:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: rocsparse@5.2.0
@@ -46,15 +46,12 @@ packages:
           - craype-accel-amd-gfx90a
   hwloc:
     buildable: false
+    require: "@2.5.0"
     externals:
-    - spec: hwloc@2.7.0
-      prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.1.0/hwloc-2.7.0-pukyd7oczgehpgx7rasxzpymkqqy3wbu
     - spec: hwloc@2.5.0
       prefix: /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/hwloc-2.5.0-4p6jkgf5ez6wr27pytkzyptppzpugu3e
-    - spec: hwloc@2.6.0a1
-      prefix: /usr
   hip:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: hip@5.2.0
@@ -63,7 +60,7 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   hsa-rocr-dev:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: hsa-rocr-dev@5.2.0
@@ -72,7 +69,7 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   llvm-amdgpu:
-    version: [5.2.0]
+    require: "@5.2.0"
     buildable: false
     externals:
       - spec: llvm-amdgpu@5.2.0
@@ -81,47 +78,47 @@ packages:
           - rocm/5.2.0
           - craype-accel-amd-gfx90a
   boost:
-    version: [1.78.0]
+    require: "@1.79.0"
     buildable: false
     externals:
-      - spec: boost@1.78.0
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.2.0/boost-1.78.0-jbrbfctoofn4arugu4odymojnwmpwzjm
+      - spec: boost@1.79.0
+        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.2/boost-1.79.0-n6rqrt7re3o7js3npdv5z3w2a5b74qsl
         modules:
-          - boost/1.78.0
+          - boost/1.79.0
   hdf5:
-    version: [1.12.1]
+    require: "@1.12.1"
     buildable: false
     externals:
       - spec: hdf5@1.12.1
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.2.0/hdf5-1.12.1-4kj7jfpwnbznydhd2xqdtij33v2bnubm/
+        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.2/hdf5-1.12.1-3ahkdeyewyzv2dajyn7l7bttknrg5xhl
         modules:
           - hdf5/1.12.1
   parallel-netcdf:
-    version: [1.12.2]
+    require: "@1.12.2"
     buildable: false
     externals:
       - spec: parallel-netcdf@1.12.2
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.2.0/parallel-netcdf-1.12.2-drkexm72gy4goprfr42vylekntbvloea
+        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.2/parallel-netcdf-1.12.2-cwutkeojgkg3yltzex26va4nwrvp5yl2
         modules:
           - parallel-netcdf/1.12.2
   cmake:
-    version: [3.23.2]
+    require: "@3.23.2"
     buildable: false
     externals:
       - spec: cmake@3.23.2
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.2.0/cmake-3.23.2-veonilm53zmocipgahbmqvnpmboyqyvt
+        prefix: /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/cmake-3.23.2-4r4mpiba7cwdw2hlakh5i7tchi64s3qd
         modules:
           - cmake/3.23.2
   zlib:
-    version: [1.2.12]
+    require: "@1.2.11"
     buildable: false
     externals:
-      - spec: zlib@1.2.12
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/clang-14.0.0-rocm5.2.0/zlib-1.2.12-3puegeev5gkgpnwp7zc4tvxouzvjjfrz
+      - spec: zlib@1.2.11
+        prefix: /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/zlib-1.2.11-zuyclcfig4tizmb2bm2h4roqsp3rwn2y
         modules:
-          - zlib/1.2.12
+          - zlib/1.2.11
   perl:
-    version: [5.34.0]
+    require: "@5.34.0"
     buildable: false
     externals:
       - spec: perl@5.34.0
@@ -129,7 +126,7 @@ packages:
         modules:
           - perl/5.34.0
   openblas:
-    version: [0.3.17]
+    require: "@0.3.17"
     buildable: false
     externals:
       - spec: openblas@0.3.17
@@ -137,16 +134,16 @@ packages:
         modules:
           - openblas/0.3.17
   umpire:
-    version: [6.0.0]
+    require: "@6.0.0"
     buildable: false
     externals:
       - spec: umpire@6.0.0
-        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.0/umpire-6.0.0-k6euxcfvl642cbaixqy4g2yircaobnot
+        prefix: /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/cce-14.0.2/umpire-6.0.0-utghddez3vndqehsesihgvljqwht4afe
         modules:
           - umpire/6.0.0
   all:
     compiler:
-      - clang@14.0.0
+      - cce@14.0.2
     providers:
       mpi: [cray-mpich@8.1.17]
       blas: [openblas]


### PR DESCRIPTION
Also switch to CCE. After using Frontier where the AMD compiler doesn't work like Crusher, I think it makes sense to switch to CCE so we will have more support and hopefully better luck transitioning to Frontier.