### PR TITLE
Turn off MPI for Eagle AMR-Wind GPU tests

### DIFF
--- a/env-templates/exawind_eagle_tests.yaml
+++ b/env-templates/exawind_eagle_tests.yaml
@@ -7,4 +7,4 @@ spack:
   view: false
   specs:
     - 'nalu-wind-nightly +fftw+tioga+hypre+openfast+cuda %gcc@9.3.0'
-    - 'amr-wind-nightly +hypre+netcdf+cuda %gcc@9.3.0'
+    - 'amr-wind-nightly +hypre+netcdf+cuda~mpi %gcc@9.3.0'


### PR DESCRIPTION
Since we're committed to using https://amrex-codes.github.io/amrex/docs_html/GPU.html#asyncarray (mostly from AMReX-Hydro) and it is a known issue that the async arena doesn't work on Eagle (and so far only Eagle) with MPI+GPU, we need to turn off MPI for the Eagle tests. Hopefully this is the only change we need to do to make that happen.