### PR TITLE
Use 32 make processes on rhodes

### DIFF
--- a/configs/rhodes/config.yaml
+++ b/configs/rhodes/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 16
+  build_jobs: 32


### PR DESCRIPTION
Since the tests are serial it makes sense to max the `make` commands.