### PR TITLE
Turn parallel dag for tests back on

### DIFF
--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -133,8 +133,11 @@ cmd "spack concretize -f"
 set +e
 printf "\nTests started at: $(date)\n\n"
 printf "spack install \n"
-time (spack install --keep-stage)
-#time (for i in {1..4}; do spack install --keep-stage & done; wait)
+if [ "${SPACK_MANAGER_MACHINE}" == 'cee' ]; then
+  time (spack install --keep-stage)
+else
+  time (for i in {1..2}; do spack install --keep-stage & done; wait)
+fi
 printf "\nTests ended at: $(date)\n"
 set -e
 


### PR DESCRIPTION
The tests aren't completing at NREL within 24 hours, so I think we need the parallel DAG.