### PR TITLE
update version range on STK patch

### DIFF
--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -30,7 +30,7 @@ class Trilinos(bTrilinos):
 
     machine = find_machine(verbose=False, full_machine_name=False)
     if machine == "eagle":
-        patch("stk-coupling-versions-func-overload.patch", when="@13.3.0:")
+        patch("stk-coupling-versions-func-overload.patch", when="@13.3.0:13.5.0.2022.12.15")
 
     depends_on("ninja", type="build", when="+ninja")
 


### PR DESCRIPTION
@jrood-nrel we have a fix for this in Trilinos/develop now.

@psakievich Trilinos is currently at 13.5, and the fix went in late in the day on Dec. 15 (so versions Dec. 16 and later should be good).  Can you confirm that my `when=` syntax is correct to continue to apply the patch for checkouts through Dec. 15?