### PR TITLE
Update a couple of crusher build settings.

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -78,7 +78,7 @@ class NaluWind(bNaluWind, ROCmPackage):
             env.set("MPICH_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set("MPICXX_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
         if "+rocm" in self.spec:
-            env.append_flags('CXXFLAGS', '--gpu-max-threads-per-block=128 -fgpu-rdc')
+            env.append_flags('CXXFLAGS', '-fgpu-rdc')
 
     def cmake_args(self):
         spec = self.spec

--- a/repos/exawind/packages/trilinos/package.py
+++ b/repos/exawind/packages/trilinos/package.py
@@ -120,7 +120,6 @@ class Trilinos(bTrilinos):
             options.append(self.define("SEACASAprepro_ENABLE_TESTS", False))
 
             options.append(self.define("Trilinos_ENABLE_TESTS", False))
-            options.append(self.define("STK_ENABLE_TESTS", False))
             options.append(self.define("Ifpack2_ENABLE_TESTS", False))
             options.append(self.define("MueLu_ENABLE_TESTS", False))
             options.append(self.define("PanzerMiniEM_ENABLE_TESTS", False))
@@ -128,6 +127,7 @@ class Trilinos(bTrilinos):
             options.append(self.define("Tpetra_ENABLE_TESTS", False))
             # STK
             options.append(self.define("Trilinos_ENABLE_STK", True))
+            options.append(self.define_from_variant("STK_ENABLE_TESTS", "stk_unit_tests"))
             options.append(self.define("Trilinos_ENABLE_STKMesh", True))
             options.append(self.define("Trilinos_ENABLE_STKIO", True))
             options.append(self.define("Trilinos_ENABLE_STKBalance", True))


### PR DESCRIPTION
1. allow for enabling stk unit-tests in the trilinos build
2. remove the gpu-max-threads-per-block flag from the nalu-wind build

*** Let's not merge this quite yet, the stk-unit-tests still need Dave's incoming commit on trilinos@develop. ***
I'll update this when that's in.
