### PR TITLE
Turn off parallel DAG in tests

### DIFF
--- a/scripts/run-exawind-nightly-tests.sh
+++ b/scripts/run-exawind-nightly-tests.sh
@@ -133,11 +133,11 @@ cmd "spack concretize -f"
 set +e
 printf "\nTests started at: $(date)\n\n"
 printf "spack install \n"
-if [ "${SPACK_MANAGER_MACHINE}" == 'cee' ]; then
-  time (spack install --keep-stage)
-else
-  time (for i in {1..2}; do spack install --keep-stage & done; wait)
-fi
+#if [ "${SPACK_MANAGER_MACHINE}" == 'cee' ]; then
+time (spack install --keep-stage)
+#else
+#  time (for i in {1..2}; do spack install --keep-stage & done; wait)
+#fi
 printf "\nTests ended at: $(date)\n"
 set -e
 


### PR DESCRIPTION
Let's try this again after the GCC hanging was resolved and the test timeouts much lower, this should hopefully complete within the day now, and hopefully solve the hanging I experience in Spack.