### PR TITLE
Make trilinos-solvers optional.

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -31,7 +31,7 @@ packages:
     version: [0.6.3]
   trilinos:
     version: [13.4.0.2022.10.27, develop]
-    variants: ~adios2~alloptpkgs~amesos+amesos2~anasazi~aztec+belos+boost~chaco~complex~debug~dtk~epetra~epetraext+exodus+explicit_template_instantiation~float~fortran~fortrilinos+glm+gtest+hdf5~hypre~ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos~mesquite+metis~minitensor~ml+mpi+muelu~mumps~nox~openmp~phalanx~piro~python~rol~rythmos~sacado+shards~shylu+stk~stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+uvm~x11~xsdkflags+zlib+zoltan+zoltan2 gotype=long cxxstd=14 build_type=Release
+    variants: ~adios2~alloptpkgs~amesos~anasazi~aztec+boost~chaco~complex~debug~dtk~epetra~epetraext+exodus+explicit_template_instantiation~float~fortran~fortrilinos+glm+gtest+hdf5~hypre~ifpack~intrepid~intrepid2~isorropia+kokkos~mesquite+metis~minitensor~ml+mpi~mumps~nox~openmp~phalanx~piro~python~rol~rythmos~sacado+shards~shylu+stk~stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+uvm~x11~xsdkflags+zlib+zoltan+zoltan2 gotype=long cxxstd=17 build_type=Release
   all:
     variants: build_type=Release +mpi
     providers:

--- a/configs/crusher/packages.yaml
+++ b/configs/crusher/packages.yaml
@@ -97,6 +97,8 @@ packages:
           - openblas/0.3.17
   trilinos:
     require: "@develop"
+  nalu-wind:
+    variants: ~trilinos-solvers
   all:
     compiler:
       - clang@15.0.0

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -45,7 +45,7 @@ class NaluWind(bNaluWind, ROCmPackage):
     depends_on("openfast@fsi+netcdf", when="+fsi")
 
     for _arch in ROCmPackage.amdgpu_targets:
-        depends_on("trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm amdgpu_target={0}".format(_arch),
+        depends_on("trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm amdgpu_target={0}".format(_arch),
                    when="+rocm amdgpu_target={0}".format(_arch))
         depends_on("hypre+rocm amdgpu_target={0}".format(_arch), when="+hypre+rocm amdgpu_target={0}".format(_arch))
 


### PR DESCRIPTION
Removed explicit activation of belos, muelu, amesos2, ifpack2 Added infrastructure for enabling/disabling them.
Also make ~trilinos-solvers default on crusher.