### PR TITLE
Disable Nalu-Wind unit tests on Eagle when using the Intel compiler

### DIFF
--- a/configs/eagle/packages.yaml
+++ b/configs/eagle/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   perl:
-    version: [5.32.0]
+    require: "@5.32.0"
   slurm:
     buildable: false
     externals:

--- a/configs/eagle/packages.yaml
+++ b/configs/eagle/packages.yaml
@@ -22,9 +22,6 @@ packages:
     variants: +mpi+fma simd=avx512
   libfabric:
     variants: fabrics=verbs
-  nalu-wind:
-    require:
-    - any_of: ["%clang", "%gcc", "%intel~unit-tests"]
   ucx:
     variants: +optimizations+gdrcopy
     version: [1.8.1]

--- a/configs/eagle/packages.yaml
+++ b/configs/eagle/packages.yaml
@@ -22,6 +22,9 @@ packages:
     variants: +mpi+fma simd=avx512
   libfabric:
     variants: fabrics=verbs
+  nalu-wind:
+    require:
+    - any_of: ["%clang", "%gcc", "%intel~unit-tests"]
   ucx:
     variants: +optimizations+gdrcopy
     version: [1.8.1]

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -52,6 +52,7 @@ class NaluWind(bNaluWind, ROCmPackage):
     cxxstd=["14", "17"]
     variant("cxxstd", default="17", values=cxxstd,  multi=False)
     variant("tests", default=True, description="Activate regression tests")
+    variant("unit-tests", default=True, description="Activate unit tests")
 
     for std in cxxstd:
         depends_on("trilinos cxxstd=%s" % std, when="cxxstd=%s" % std)
@@ -94,8 +95,6 @@ class NaluWind(bNaluWind, ROCmPackage):
         if spec.satisfies("dev_path=*"):
             cmake_options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
             cmake_options.append(self.define("ENABLE_TESTS", True))
-            if find_machine(verbose=False) == "eagle" and "%intel" in spec:
-                cmake_options.append(self.define("ENABLE_UNIT_TESTS", False))
 
         if "+rocm" in self.spec:
             cmake_options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -88,6 +88,9 @@ class NaluWind(bNaluWind, ROCmPackage):
         cmake_options.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
         cmake_options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
+        if find_machine(verbose=False) == "eagle" and "%intel" in spec:
+            cmake_options.append(self.define("ENABLE_UNIT_TESTS", False))
+
         if find_machine(verbose=False) == "crusher":
             cmake_options.append(self.define("MPIEXEC_EXECUTABLE", "srun"))
             cmake_options.append(self.define("MPIEXEC_NUMPROC_FLAG", "--ntasks"))
@@ -96,8 +99,8 @@ class NaluWind(bNaluWind, ROCmPackage):
             cmake_options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
             cmake_options.append(self.define("ENABLE_TESTS", True))
 
-        if "+rocm" in self.spec:
-            cmake_options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
+        if "+rocm" in spec:
+            cmake_options.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
             cmake_options.append(self.define("ENABLE_ROCM", True))
             targets = spec.variants["amdgpu_target"].value
             cmake_options.append(self.define("GPU_TARGETS", ";".join(str(x) for x in targets)))

--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -94,6 +94,8 @@ class NaluWind(bNaluWind, ROCmPackage):
         if spec.satisfies("dev_path=*"):
             cmake_options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
             cmake_options.append(self.define("ENABLE_TESTS", True))
+            if find_machine(verbose=False) == "eagle" and "%intel" in spec:
+                cmake_options.append(self.define("ENABLE_UNIT_TESTS", False))
 
         if "+rocm" in self.spec:
             cmake_options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))


### PR DESCRIPTION
I tried to get this logic into the Eagle `packages.yaml`, but the `require` doesn't have a `when` clause to only use the `unit-tests` variant when `%intel` is in use, so it has to go in `nalu-wind/package.py`.