### PR TITLE
Require ofast c++ bindings with +fsi

### DIFF
--- a/repos/exawind/packages/nalu-wind/package.py
+++ b/repos/exawind/packages/nalu-wind/package.py
@@ -45,7 +45,7 @@ class NaluWind(bNaluWind, ROCmPackage):
     depends_on("hypre+umpire", when="+umpire")
 
     depends_on("trilinos gotype=long")
-    depends_on("openfast@fsi+netcdf", when="+fsi")
+    depends_on("openfast@fsi+netcdf+cxx", when="+fsi")
 
     for _arch in ROCmPackage.amdgpu_targets:
         depends_on("trilinos@13.4.0.2022.10.27: ~shared+exodus+tpetra+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+rocm amdgpu_target={0}".format(_arch),


### PR DESCRIPTION
This requirement was not carried over to the fsi branch from spack's builtin repo. @gantech @deslaughter