### PR TITLE
Get compile_commands.json working for tioga

### DIFF
--- a/repos/exawind/packages/tioga/package.py
+++ b/repos/exawind/packages/tioga/package.py
@@ -21,7 +21,7 @@ class Tioga(bTioga, SMCMakeExtension):
         options = super(Tioga, self).cmake_args()
 
         if spec.satisfies("dev_path=*"):
-            cmake_options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
+            options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
 
         return options
 

--- a/repos/exawind/packages/tioga/package.py
+++ b/repos/exawind/packages/tioga/package.py
@@ -20,8 +20,8 @@ class Tioga(bTioga, SMCMakeExtension):
         spec = self.spec
         options = super(Tioga, self).cmake_args()
 
-        if "dev_path" in spec:
-            options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
+        if spec.satisfies("dev_path=*"):
+            cmake_options.append(self.define("CMAKE_EXPORT_COMPILE_COMMANDS",True))
 
         return options
 


### PR DESCRIPTION
Not sure why the old syntax didn't work, but it must not have worked since @PaulMullowney hit an error with the file not exisiting