### PR TITLE
Change preference ordering for mpi on CEE

### DIFF
--- a/configs/cee/packages.yaml
+++ b/configs/cee/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
     compiler: [gcc, clang, intel]
     providers:
-      mpi: [mpich, openmpi, mvapich2]
+      mpi: [openmpi, mpich, mvapich2]
     variants: +mpi build_type=Release cuda_arch=70
     target: [x86_64]
   boost:


### PR DESCRIPTION
This __should__ fix our issues with picking `mpich` over `openmpi`