### PR TITLE
Auto detected dev specs will be minimal required

### DIFF
--- a/docs/user_profiles/developers/developer_workflow.md
+++ b/docs/user_profiles/developers/developer_workflow.md
@@ -119,12 +119,12 @@ See below for an example of how to use option2.
 
 ```console
 # create an environment and acticate it with "quick-create"
+# then clone the "amr-feature" branch from a user specific fork of the amr-wind git repo
+# then clone the "openfast-feature" branch from a user specific fork of the openfast git repo
+# finally build the software using the source code that was just cloned
 quick-create -n build-from-my-fork -s amr-wind+openfast
-# clone the "amr-feature" branch from a user specific fork of the amr-wind git repo
 spack manager develop --repo-branch git@github.com:psakievich/amr-wind.git amr-feature amr-wind@main
-# clone the "openfast-feature" branch from a user specific fork of the openfast git repo
 spack manager develop --repo-branch git@github.com:psakievich/openfast.git openfast-feature openfast@master
-# build the software using the source code that was just cloned
 spack install
 ```
 

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -52,7 +52,7 @@ def create_dev_env(parser, args):
             dev_args.extend(["--path", env.yaml["spack"]["develop"][str(s.name)]["path"]])
         if "trilinos" in str(s.name):
             dev_args.extend(["-rb", "git@github.com:trilinos/trilinos.git", str(s.version)])
-        dev_args.append(str(s))
+        dev_args.append(str(s.format("{name}{@version}")))
         develop(dev_args)
     ev.deactivate()
 


### PR DESCRIPTION
Currently spack-manager just copies the entire spec you give it when using create-dev-env.  Now it will strip it to the minimal required spec of `{name}@{version}`. This is to make it easier to read, edit, and encourage matches.  Also a recent change in behavior in spack was detected by @alanw0 in which full specs to fail some times. We do not yet understand what caused that to occur.