### PR TITLE
Make spack-manager environments managed environments

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -24,6 +24,10 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
     spack bootstrap root ${SPACK_MANAGER}/.bootstrap
   fi
 
+  if [[ -z $(spack config blame config | grep "environments_root: ${SPACK_MANAGER}/environments") ]]; then
+    spack config add config:environments_root:${SPACK_MANAGER}/environments
+  fi
+
   if [[ -z $(spack config --scope site blame config | grep spack-scripting) ]]; then
     spack config --scope site add "config:extensions:[${SPACK_MANAGER}/spack-scripting]"
     spack config --scope site add "concretizer:unify:false"

--- a/spack-scripting/tests/test_external.py
+++ b/spack-scripting/tests/test_external.py
@@ -107,12 +107,7 @@ def test_errorsIfThereIsNoView(tmpdir):
         path = tmpdir.join("spack.yaml")
         with open(str(path), "w") as f:
             f.write(yaml_file)
-        env(
-            "create",
-            "-d",
-            "test",
-            "spack.yaml",
-        )
+        env("create", "-d", "test", "spack.yaml")
         args = ParserMock(ext_env)
         with pytest.raises(SystemExit):
             with ev.Environment("test"):
@@ -144,12 +139,7 @@ def evaluate_external(tmpdir, yaml_file):
     with open(str(manifest), "w") as f:
         f.write(yaml_file)
 
-    env(
-        "create",
-        "-d",
-        "test",
-        "spack.yaml",
-    )
+    env("create", "-d", "test", "spack.yaml")
     assert os.path.isfile("test/spack.yaml")
 
     with ev.Environment("test") as e:


### PR DESCRIPTION
This PR makes it so the environments in `$SPACK_MANAGER/environments` will be managed by spack. This leads to more robust checking to ensure you don't accidentally delete a dependency being used by one of these environments.

In a follow on PR we should probably update the syntax of `spack manager create-env` to remove the the `--name` flag since this will now be the default location that spack will create environments.  

I'd like to merge it so this aligns more directly with `spack env create`.