### PR TITLE
Don't need rocm module with PrgEnv-amd

### DIFF
--- a/configs/crusher/compilers.yaml
+++ b/configs/crusher/compilers.yaml
@@ -11,7 +11,7 @@ compilers:
       target: any
       modules:
       - PrgEnv-amd/8.3.3
-      - rocm/5.4.3
+      #- rocm/5.4.3
       - amd/5.4.3
       - libfabric
       - craype-x86-trento

--- a/configs/frontier/compilers.yaml
+++ b/configs/frontier/compilers.yaml
@@ -11,7 +11,7 @@ compilers:
       target: any
       modules:
       - PrgEnv-amd/8.3.3
-      - rocm/5.4.3
+      #- rocm/5.4.3
       - amd/5.4.3
       - libfabric
       - craype-x86-trento


### PR DESCRIPTION
It actually causes an error on the command line if you try to have both `amd` and `rocm` loaded simultaneously, and it looks like the `amd` module is a superset of `rocm`.