### PR TITLE
Move Eagle to default to single CPU intel build

### DIFF
--- a/env-templates/exawind_eagle.yaml
+++ b/env-templates/exawind_eagle.yaml
@@ -1,0 +1,9 @@
+spack:
+  include:
+  - include.yaml
+  concretizer:
+    unify: false
+    reuse: false
+  view: false
+  specs:
+    - 'exawind+ninja+hypre~amr_wind_gpu~nalu_wind_gpu~cuda%intel'

--- a/env-templates/exawind_summit.yaml
+++ b/env-templates/exawind_summit.yaml
@@ -1,0 +1,12 @@
+spack:
+  include:
+  - include.yaml
+  concretizer:
+    unify: false
+    reuse: false
+  view: false
+  specs:
+    - 'exawind+ninja+hypre+amr_wind_gpu+nalu_wind_gpu+cuda+fsi'
+    - 'exawind+ninja+hypre+amr_wind_gpu+nalu_wind_gpu+cuda'
+    - 'exawind+ninja+hypre~amr_wind_gpu~nalu_wind_gpu~cuda'
+    - 'exawind+ninja+hypre+amr_wind_gpu~nalu_wind_gpu+cuda'

--- a/scripts/install-exawind.sh
+++ b/scripts/install-exawind.sh
@@ -37,9 +37,12 @@ if [[ -f "${ENV_SCRIPT}" ]]; then
 fi
 
 printf "\nCreating Spack environment...\n"
-if [ "${SPACK_MANAGER_MACHINE}" == 'eagle' ] || [ "${SPACK_MANAGER_MACHINE}" == 'summit' ]; then
-  cmd "spack manager create-env -y ${SPACK_MANAGER}/env-templates/exawind_matrix.yaml -d ${SPACK_MANAGER}/environments/exawind-${SPACK_MANAGER_MACHINE}"
-elif [ "${SPACK_MANAGER_MACHINE}" == 'spock' ] || [ "${SPACK_MANAGER_MACHINE}" == 'crusher' ] || [ "${SPACK_MANAGER_MACHINE}" == 'frontier' ] || [ "${SPACK_MANAGER_MACHINE}" == 'azure' ]; then
+if [ "${SPACK_MANAGER_MACHINE}" == 'eagle' ] || \
+   [ "${SPACK_MANAGER_MACHINE}" == 'summit' ] || \
+   [ "${SPACK_MANAGER_MACHINE}" == 'spock' ] || \
+   [ "${SPACK_MANAGER_MACHINE}" == 'crusher' ] || \
+   [ "${SPACK_MANAGER_MACHINE}" == 'frontier' ] || \
+   [ "${SPACK_MANAGER_MACHINE}" == 'azure' ]; then
   cmd "spack manager create-env -y ${SPACK_MANAGER}/env-templates/exawind_${SPACK_MANAGER_MACHINE}.yaml -d ${SPACK_MANAGER}/environments/exawind-${SPACK_MANAGER_MACHINE}"
 else
   cmd "spack manager create-env -s exawind+hypre+openfast+ninja -d ${SPACK_MANAGER}/environments/exawind-${SPACK_MANAGER_MACHINE}"


### PR DESCRIPTION
Since we don't really build with CUDA on Eagle, this makes more sense. Then Summit was the only machine left using the example matrix.