### PR TITLE
Add ROSCO package

### DIFF
--- a/repos/exawind/packages/openfast/package.py
+++ b/repos/exawind/packages/openfast/package.py
@@ -14,7 +14,7 @@ class Openfast(bOpenfast):
     patch("segfault_message.patch", when="%clang@12.0.1 build_type=RelWithDebInfo")
     version("fsi", git="https://github.com/gantech/openfast.git", branch="f/br_fsi_2")
 
-    variant("rosco", default=True,
+    variant("rosco", default=False,
             description="Build ROSCO controller alongside OpenFAST")
 
     depends_on("rosco", when="+rosco")

--- a/repos/exawind/packages/openfast/package.py
+++ b/repos/exawind/packages/openfast/package.py
@@ -14,6 +14,11 @@ class Openfast(bOpenfast):
     patch("segfault_message.patch", when="%clang@12.0.1 build_type=RelWithDebInfo")
     version("fsi", git="https://github.com/gantech/openfast.git", branch="f/br_fsi_2")
 
+    variant("rosco", default=True,
+            description="Build ROSCO controller alongside OpenFAST")
+
+    depends_on("rosco", when="+rosco")
+
     #def setup_build_environment(self, env):
     #    spec = self.spec
     #    machine = find_machine(verbose=False, full_machine_name=False)

--- a/repos/exawind/packages/rosco/package.py
+++ b/repos/exawind/packages/rosco/package.py
@@ -47,7 +47,6 @@ class Rosco(CMakePackage):
         options.extend(
             [
                 self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-                self.define("CMAKE_Fortran_FLAGS", "-ffree-line-length-0"),
                 self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
             ]
         )
@@ -57,3 +56,12 @@ class Rosco(CMakePackage):
     def setup_run_environment(self, env):
         env.set('ROSCO_DISCON', self.prefix.lib + "/libdiscon.so")
         env.set('ROSCO_DISCON_DIR', self.prefix.lib)
+
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        is_gcc = spec.compiler.name in ["gcc"]
+
+        if is_gcc:
+            flags.append("-ffree-line-length-0")
+        
+        return (flags, None, None)

--- a/repos/exawind/packages/rosco/package.py
+++ b/repos/exawind/packages/rosco/package.py
@@ -7,9 +7,11 @@ from spack.package import *
 
 
 class Rosco(CMakePackage):
-    """ROSCO controls package for OpenFAST from NREL"""
-    # Note: this only builds ROSCO controls library for inclusion with OpenFAST
-    # If the toolbox or tuning scripts are needed, please build manually
+    """
+    ROSCO controls package for OpenFAST from NREL
+    Note: this only builds ROSCO controls library for inclusion with OpenFAST
+    If the toolbox or tuning scripts are needed, please build manually
+    """
 
     homepage = "https://rosco.readthedocs.io/en/latest/"
     git = "https://github.com/NREL/ROSCO.git"

--- a/repos/exawind/packages/rosco/package.py
+++ b/repos/exawind/packages/rosco/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Rosco(CMakePackage):
+    """ROSCO controls package for OpenFAST from NREL"""
+    # Note: this only builds ROSCO controls library for inclusion with OpenFAST
+    # If the toolbox or tuning scripts are needed, please build manually
+
+    homepage = "https://rosco.readthedocs.io/en/latest/"
+    git = "https://github.com/NREL/ROSCO.git"
+
+    maintainers("dzalkind","ndevelder")
+
+    version("develop", branch="develop")
+    version("main", branch="main")
+    version("2.8.0", tag="v2.8.0")
+    version("2.7.0", tag="v2.7.0")
+    version("2.6.0", tag="v2.6.0")
+    version("2.5.1", tag="v2.5.1")
+    version("2.5.0", tag="v2.5.0")
+    version("2.4.1", tag="v2.4.1")
+    version("2.4.0", tag="v2.4.0")
+    version("2.3.0", tag="v2.3.0")
+    version("2.2.0", tag="v2.2.0")
+
+
+    variant("shared", default=False, description="Build shared libraries")
+    variant("pic", default=False, description="Position independent code")
+
+    # Dependencies for OpenFAST Fortran
+    # depends_on("openfast")
+
+    root_cmakelists_dir = 'ROSCO'
+
+    def cmake_args(self):
+        spec = self.spec
+
+        options = []
+
+        options.extend(
+            [
+                self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+                self.define("CMAKE_Fortran_FLAGS", "-ffree-line-length-0"),
+                self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            ]
+        )
+
+        return options
+
+    def setup_run_environment(self, env):
+        env.set('ROSCO_DISCON', self.prefix.lib + "/libdiscon.so")
+        env.set('ROSCO_DISCON_DIR', self.prefix.lib)


### PR DESCRIPTION
ROSCO is a controls library commonly used with OpenFAST. This adds a package allowing user to build ROSCO. When loaded, package gives the env variable $ROSCO_DISCON which can be echoed and copied into ServoDyn. 