### PR TITLE
Require ~ssl for python on frontier

### DIFF
--- a/configs/frontier/packages.yaml
+++ b/configs/frontier/packages.yaml
@@ -97,7 +97,8 @@ packages:
           - openblas/0.3.17
   umpire:
     require: "@6.0.0"
-
+  python:
+    require: "~ssl"
   trilinos:
     require:
       - any_of: ["@13.4.0.2023.02.28", "@develop"]


### PR DESCRIPTION
I think this is the last piece to the Frontier update.