### PR TITLE
CEE: Force configs for cuda builds

### DIFF
--- a/configs/cee/packages.yaml
+++ b/configs/cee/packages.yaml
@@ -1,20 +1,19 @@
 packages:
   all:
     compiler: [gcc, clang, intel]
-    providers:
-      mpi: [openmpi, mpich, mvapich2]
     variants: +mpi build_type=Release cuda_arch=70
     target: [x86_64]
   boost:
     version: [1.80.0]
   cmake:
+    require: "cmake@3.25.0"
     externals:
-    - spec: cmake@3.22.2
-      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/cmake-3.22.2-s67tgoaqaw4ky5kmpuzxdg5une7xouvh/
-    - spec: cmake@3.25.0%clang@13.0.1~doc+ncurses+ownlibs~qt build_type=Release arch=linux-rhel7-x86_64
-      prefix: /projects/wind/core-spack-manager/scripts/admin-system-setup/packages/.spack-env/view/clang/13.0.1/cmake/3.25.0/flff6w2l
     - spec: cmake@3.25.0%gcc@10.3.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-rhel7-x86_64
       prefix: /projects/wind/core-spack-manager/scripts/admin-system-setup/packages/.spack-env/view/gcc/10.3.0/cmake/3.25.0/vfumwtcx
+    - spec: cmake@3.25.0%clang@13.0.1~doc+ncurses+ownlibs~qt build_type=Release arch=linux-rhel7-x86_64
+      prefix: /projects/wind/core-spack-manager/scripts/admin-system-setup/packages/.spack-env/view/clang/13.0.1/cmake/3.25.0/flff6w2l
+    - spec: cmake@3.22.2
+      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/cmake-3.22.2-s67tgoaqaw4ky5kmpuzxdg5une7xouvh/
     buildable: false
   cuda:
     externals:
@@ -45,17 +44,8 @@ packages:
       prefix: /usr/
   openblas:
     version: [0.3.10]
-  mpich:
-    externals:
-    - spec: mpich@3.4.2%gcc@9.3.0
-      prefix: /projects/wind/system-spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/mpich-3.4.2-4h2muy6jlgfdahehxmxa4ybndfdb6gx2/
-    buildable: false
-  mvapich2:
-    externals:
-    - spec: mvapich2@2.3.7%gcc@10.3.0~alloca~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32
-        fabrics=mrail file_systems=auto process_managers=auto threads=multiple arch=linux-rhel7-x86_64
-      prefix: /projects/wind/core-spack-manager/scripts/admin-system-setup/packages/.spack-env/view/gcc/10.3.0/mvapich2/2.3.7/lygp3cww
-    buildable: false
+  mpi:
+    require: "openmpi@4.0.2"
   openmpi:
     externals:
     - spec: openmpi@4.0.2%clang@13.0.1~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java+legacylaunchers~lustre~memchecker+romio+rsh~singularity+static+vt+wrapper-rpath

--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -17,9 +17,14 @@ class MachineData:
 
 
 def is_cee(hostname):
+    site = False
+    system = False
     if "SNLSITE" in os.environ:
-        return os.environ["SNLSITE"] == "cee"
-    return False
+        site = os.environ["SNLSITE"] == "cee"
+    if "SNLSYSTEM" in os.environ:
+        system = os.environ["SNLSYSTEM"] == "cee"
+    detected = site or system
+    return detected
 
 
 def is_snl_hpc(hostname):


### PR DESCRIPTION
Force the configs to give us the cuda builds we want. Does use an openmpi build with gcc@10.3.0 with a gcc@9.3.0 stack. Testing to see if that is an issue but this is the fastest way forward.