### PR TITLE
Perlmutter: update xpmem version for Perlmutter

### DIFF
--- a/configs/perlmutter/compilers.yaml
+++ b/configs/perlmutter/compilers.yaml
@@ -21,4 +21,4 @@ compilers:
     extra_rpaths: []
     environment:
       prepend_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.50__gd0f7936.shasta/lib64/pkgconfig
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.6.2-2.5_2.27__gd067c3f.shasta/lib64/pkgconfig/

--- a/configs/perlmutter/packages.yaml
+++ b/configs/perlmutter/packages.yaml
@@ -9,7 +9,7 @@ packages:
           - gcc/11.2.0
           - libfabric/1.15.2.0
           - craype-network-ofi
-          - xpmem/2.5.2-2.4_3.50__gd0f7936.shasta
+          - xpmem/2.6.2-2.5_2.27__gd067c3f.shasta
           - craype-x86-milan
           - xalt/2.10.2
   cuda:


### PR DESCRIPTION
This PR updates XPMEM versions for Perlmutter in `configs/packages.yaml` and `configs/compilers.yaml`.  Perlmutter was upgraded Sept. 28 - 29, 2023. 