### PR TITLE
Container for (spack-manager) CUDA GPU Build of Exawind  for NERSC Science Platform

### DIFF
--- a/configs/containergpucuda/compilers.yaml
+++ b/configs/containergpucuda/compilers.yaml
@@ -1,6 +1,6 @@
 compilers:
 - compiler:
-    spec: nvcc@=12.2.91
+    spec: gcc@11.4.0 
     paths:
       cc: /usr/bin/gcc
       cxx: /usr/bin/g++

--- a/configs/containergpucuda/compilers.yaml
+++ b/configs/containergpucuda/compilers.yaml
@@ -1,0 +1,13 @@
+compilers:
+- compiler:
+    spec: gcc@11.4.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu22.04
+    target: any
+    modules: []
+    extra_rpaths: []

--- a/configs/containergpucuda/compilers.yaml
+++ b/configs/containergpucuda/compilers.yaml
@@ -1,6 +1,6 @@
 compilers:
 - compiler:
-    spec: gcc@11.4.0
+    spec: nvcc@=12.2.91
     paths:
       cc: /usr/bin/gcc
       cxx: /usr/bin/g++
@@ -11,3 +11,5 @@ compilers:
     target: any
     modules: []
     extra_rpaths: []
+
+# See example:  https://spack.readthedocs.io/en/latest/gpu_configuration.html

--- a/configs/containergpucuda/config.yaml
+++ b/configs/containergpucuda/config.yaml
@@ -1,0 +1,2 @@
+config:
+  build_jobs: 32

--- a/configs/containergpucuda/config.yaml
+++ b/configs/containergpucuda/config.yaml
@@ -1,2 +1,2 @@
 config:
-  build_jobs: 32
+  build_jobs: 20

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -7,40 +7,12 @@ packages:
       mpi: [mpich]
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
-    variants: build_type=Release
+    variants: build_type=Release cuda_arch=80
   mpi:
     require: mpich
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml
   mpich:
-    require:
-      - one_of: ["+cuda", "+rocm"]
-# Use CUDA resources from NVIDIA base image: 
-# See example:  https://spack.readthedocs.io/en/latest/gpu_configuration.html
-  cuda:
-    buildable: false
-    externals:
-    - spec: cuda@12.2.91
-      prefix: /usr/local/cuda
-  cusparse:
-    buildable: false
-    externals:
-    - spec: cuda@12.2.91
-      prefix: /usr/local/cuda
-  cublas:
-    buildable: false
-    externals:
-    - spec: cuda@12.2.91
-      prefix: /usr/local/cuda
-  cusolver:
-    buildable: false
-    externals:
-    - spec: cuda@12.2.91
-      prefix: /usr/local/cuda
-  cufft:
-    buildable: false
-    externals:
-    - spec: cuda@12.2.91
-      prefix: /usr/local/cuda
+    require: "+cuda"
 # Use Ubuntu libncurses-dev, b/c Spack version fails 
   ncurses:
     externals:

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -13,10 +13,18 @@ packages:
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml
   mpich:
     require: "+cuda"
-# Use Ubuntu libncurses-dev, b/c Spack version fails 
+# Use Ubuntu libncurses-dev, etc., b/c Spack version fails 
   ncurses:
     externals:
     - spec: ncurses@6.3
+      prefix: /usr
+  gdbm:
+    externals:
+    - spec: gdbm@1.23
+      prefix: /usr
+  gdbm6:
+    externals:
+    - spec: gdbm6@1.23
       prefix: /usr
 # Package preferences to be built by Spack for correct Exawind
 # Nota bene: use libtool from Spack for correct linking

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -8,9 +8,44 @@ packages:
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
     variants: build_type=Release
-# External packages from nvidia base image (Ubuntu-22.04)
   mpi:
     require: mpich
+# GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml
+  mpich:
+    require:
+      - one_of: ["+cuda", "+rocm"]
+# Use CUDA resources from NVIDIA base image: 
+# See example:  https://spack.readthedocs.io/en/latest/gpu_configuration.html
+  cuda:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+  cusparse:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+  cublas:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+  cusolver:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+  cufft:
+    buildable: false
+    externals:
+    - spec: cuda@12.2.91
+      prefix: /usr/local/cuda
+# Use Ubuntu libncurses-dev, b/c Spack version fails 
+  ncurses:
+    externals:
+    - spec: ncurses@6.3
+      prefix: /usr
 # Package preferences to be built by Spack for correct Exawind
 # Nota bene: use libtool from Spack for correct linking
   ascent:

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -7,7 +7,7 @@ packages:
       mpi: [mpich]
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
-    variants: build_type=Release cuda_arch=70
+    variants: build_type=Release cuda_arch=80
   mpi:
     require: mpich
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -1,0 +1,58 @@
+packages:
+# Global settings
+  all:
+    compiler:
+    - gcc@11.4.0
+    providers:
+      mpi: [mpich]
+      blas: [netlib-lapack]
+      lapack: [netlib-lapack]
+    variants: build_type=Release
+# External packages from nvidia base image (Ubuntu-22.04)
+  mpi:
+    require: mpich
+# Package preferences to be built by Spack for correct Exawind
+# Nota bene: use libtool from Spack for correct linking
+  ascent:
+    variants: ~fortran~openmp
+  amr-wind:
+    variants: +tiny_profile
+  conduit:
+    variants: ~fortran~hdf5_compat
+  boost:
+    version: [1.78.0]
+    variants: cxxstd=17
+  cmake:
+    version: [3.26.3]
+    variants: build_type=Release
+  trilinos:
+    require:
+      - any_of: ["@13.4.0", "@develop"]
+  hdf5:
+    version: [1.10.7]
+    variants: +cxx+hl
+  libtool:
+    version: [2.4.7]
+  masa:
+    variants: ~fortran~python
+  netcdf-c:
+    require: '@4.7.4'
+    variants: +parallel-netcdf maxdims=65536 maxvars=524288
+  openfast:
+    version: [master]
+    variants: +cxx
+  parallel-netcdf:
+    version: [1.12.2]
+    variants: ~fortran
+  perl:
+    require: '@5.34.1'
+  tioga:
+    version: [develop]
+  hypre:
+    require: '@develop'
+    variants: ~fortran
+  hypre2:
+    require: '@develop'
+    variants: ~fortran
+  yaml-cpp:
+    version: [0.6.3]

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -11,13 +11,14 @@ packages:
   mpi:
     require: mpich
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml
-  mpich:
-    require: "+cuda"
+#  mpich:
+#    require: "+cuda"
 # Use Ubuntu libncurses-dev, etc., b/c Spack version fails
 # Spack-pinned version of mpich builds fail  
   mpich:
     externals:
     - spec: mpich@4.0
+      require: "+cuda"
       prefix: /usr
   ncurses:
     externals:

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -7,7 +7,7 @@ packages:
       mpi: [mpich]
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
-    variants: build_type=Release cuda_arch=80
+    variants: build_type=Release cuda_arch=70
   mpi:
     require: mpich
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml

--- a/configs/containergpucuda/packages.yaml
+++ b/configs/containergpucuda/packages.yaml
@@ -13,7 +13,12 @@ packages:
 # GPU-aware MPICH; See - https://spack.readthedocs.io/en/latest/build_settings.html#package-settings-packages-yaml
   mpich:
     require: "+cuda"
-# Use Ubuntu libncurses-dev, etc., b/c Spack version fails 
+# Use Ubuntu libncurses-dev, etc., b/c Spack version fails
+# Spack-pinned version of mpich builds fail  
+  mpich:
+    externals:
+    - spec: mpich@4.0
+      prefix: /usr
   ncurses:
     externals:
     - spec: ncurses@6.3

--- a/env-templates/exawind_containergpucuda.yaml
+++ b/env-templates/exawind_containergpucuda.yaml
@@ -1,0 +1,9 @@
+spack:
+  include:
+  - include.yaml
+  concretizer:
+    unify: false
+    reuse: false 
+  view: false
+  specs:
+    - 'exawind+hypre+amr_wind_gpu+nalu_wind_gpu+cuda'

--- a/exawind_containergpucuda.yaml
+++ b/exawind_containergpucuda.yaml
@@ -1,0 +1,9 @@
+spack:
+  include:
+  - include.yaml
+  concretizer:
+    unify: false
+    reuse: false 
+  view: false
+  specs:
+    - 'exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu'

--- a/exawind_containergpucuda.yaml
+++ b/exawind_containergpucuda.yaml
@@ -1,9 +1,0 @@
-spack:
-  include:
-  - include.yaml
-  concretizer:
-    unify: false
-    reuse: false 
-  view: false
-  specs:
-    - 'exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu'

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -6,8 +6,6 @@ MAINTAINER Jon Rood, NREL <Jon.Rood@nrel.gov>
 ARG REGISTRY=nvcr.io/nvidia
 ARG IMAGE=cuda
 ARG TAG=11.8.0-devel-ubuntu22.04
-#ARG TAG=12.1.0-devel-ubuntu22.04
-#ARG TAG=12.2.0-devel-ubuntu22.04
 
 FROM ${REGISTRY}/${IMAGE}:${TAG}
 

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -39,6 +39,9 @@ RUN apt-get update -y && \
     libgmp-dev \
     libjpeg-dev \
     libmpc-dev \
+    libnccl2 \
+    libnccl-dev \
+    libncurses-dev \
     libx11-dev \
     lsb-release \
     m4 \
@@ -59,16 +62,16 @@ RUN apt clean -y
 WORKDIR /exawind-entry
 #RUN git clone --recursive https://github.com/sandialabs/spack-manager
 # Pre-merge fork
-#RUN git clone --recursive https://github.com/ajpowelsnl/spack-manager
+RUN git clone --recursive https://github.com/ajpowelsnl/spack-manager
 # Needed by "create-exawind-snapshot.sh"
 ENV SPACK_MANAGER_MACHINE=containergpucuda
 ENV CONTAINER_BUILD=gpucuda
 ENV SPACK_MANAGER=/exawind-entry/spack-manager
 
-#WORKDIR /exawind-entry/spack-manager
+WORKDIR /exawind-entry/spack-manager
 
 # Pre-merge branch from ajpowelsnl/spack-manager fork
-#RUN git checkout gpucontainer
+RUN git checkout gpucontainer
 
 # Snapshot will be generated upon running container
 #RUN echo "export SPACK_MANAGER=$SPACK_MANAGER" >> /etc/bash.bashrc && \

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -34,9 +34,13 @@ RUN apt-get update -y && \
     git \
     git-doc \
     git-man \
+    hwloc-nox \
     libffi-dev \
     libfmt-dev \
     libgmp-dev \
+    libhwloc-common \
+    libhwloc-dev \
+    libhwloc15 \
     libjpeg-dev \
     libmpc-dev \
     libnccl2 \
@@ -76,13 +80,12 @@ RUN git checkout gpucontainer
 # Snapshot will be generated upon running container
 #RUN echo "export SPACK_MANAGER=$SPACK_MANAGER" >> /etc/bash.bashrc && \
 #    echo "source $SPACK_MANAGER/start.sh && spack-start" >> /etc/bash.bashrc && \
-#    echo "spack external find" >> /etc/bash.bashrc && \
-#    echo "spack config add packages:all:target:[$uarch]" >> /etc/bash.bashrc && \
+#    echo "spack external find --all" >> /etc/bash.bashrc && \
 #    echo "$SPACK_MANAGER/scripts/create-exawind-snapshot.sh" >> /etc/bash.bashrc && \
 #    echo "spack clean -a" >> /etc/bash.bashrc
 
 # Verify .bashrc
 # RUN ["/bin/bash", "-c", "tail -n 6 /etc/bash.bashrc"]
 
-WORKDIR /exawind-entry
+#WORKDIR /exawind-entry
 CMD [ "/bin/bash" ]

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -15,11 +15,15 @@ SHELL ["/bin/bash", "-c"]
 # Install Spack Prereqs: https://spack.readthedocs.io/en/latest/getting_started.html#system-prerequisites
 
 RUN apt-get update -y && \
-    apt-get -y upgrade && \
-    apt-get -y install \
+    apt-get upgrade -y
+
+RUN apt-get install -y \
     autoconf \
     automake \
+    bzip2 \
+    ca-certificates \
     clangd \
+    coreutils \
     curl \
     emacs-nox \
     file \
@@ -34,7 +38,9 @@ RUN apt-get update -y && \
     git \
     git-doc \
     git-man \
+    gnupg2 \
     hwloc-nox \
+    libbz2-dev \
     libffi-dev \
     libfmt-dev \
     libgmp-dev \
@@ -49,6 +55,7 @@ RUN apt-get update -y && \
     libx11-dev \
     lsb-release \
     m4 \
+    make \
     nano \
     python3 \
     python3-distutils \
@@ -57,6 +64,7 @@ RUN apt-get update -y && \
     vim \
     wget \
     wget2 \
+    xz-utils \
     zip \
     zlib1g-dev
 

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -4,8 +4,8 @@ LABEL maintainer="Philip Sakievich, Sandia National Laboratories <psakiev@sandia
 
 ARG REGISTRY=nvcr.io/nvidia
 ARG IMAGE=cuda
-#ARG TAG=11.8.0-devel-ubuntu22.04
-ARG TAG=12.2.0-devel-ubuntu22.04
+ARG TAG=11.8.0-devel-ubuntu22.04
+#ARG TAG=12.2.0-devel-ubuntu22.04
 
 FROM ${REGISTRY}/${IMAGE}:${TAG}
 
@@ -52,10 +52,15 @@ RUN apt-get install -yqq \
     libjpeg-dev \
     libmpc-dev \
     libncurses-dev \
+    libtool \
+    libtool-bin \
+    libtool-doc \
     libx11-dev \
     lsb-release \
     m4 \
     make \
+    mpich \
+    mpich-doc \
     nano \
     python3 \
     python3-distutils \

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -5,7 +5,9 @@ MAINTAINER Jon Rood, NREL <Jon.Rood@nrel.gov>
 
 ARG REGISTRY=nvcr.io/nvidia
 ARG IMAGE=cuda
-ARG TAG=12.2.0-devel-ubuntu22.04
+ARG TAG=11.8.0-devel-ubuntu22.04
+#ARG TAG=12.1.0-devel-ubuntu22.04
+#ARG TAG=12.2.0-devel-ubuntu22.04
 
 FROM ${REGISTRY}/${IMAGE}:${TAG}
 
@@ -51,8 +53,6 @@ RUN apt-get install -y \
     libhwloc15 \
     libjpeg-dev \
     libmpc-dev \
-    libnccl2 \
-    libnccl-dev \
     libncurses-dev \
     libx11-dev \
     lsb-release \

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -1,0 +1,85 @@
+MAINTAINER Philip Sakievich, Sandia National Laboratories <psakiev@sandia.gov>
+MAINTAINER Jon Rood, NREL <Jon.Rood@nrel.gov>
+
+# NVIDIA base images:  https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags
+
+ARG REGISTRY=nvcr.io/nvidia
+ARG IMAGE=cuda
+ARG TAG=12.2.0-devel-ubuntu22.04
+
+FROM ${REGISTRY}/${IMAGE}:${TAG}
+
+# Make bash the default $SHELL
+SHELL ["/bin/bash", "-c"]
+
+# Install Spack Prereqs: https://spack.readthedocs.io/en/latest/getting_started.html#system-prerequisites
+
+RUN apt-get update -y && \
+    apt-get -y upgrade && \
+    apt-get -y install \
+    autoconf \
+    automake \
+    clangd \
+    curl \
+    emacs-nox \
+    file \
+    flex \
+    gcc \
+    gcc-multilib \
+    gcc-doc \
+    g++ \
+    gfortran \
+    gfortran-multilib \
+    gfortran-doc \
+    git \
+    git-doc \
+    git-man \
+    libffi-dev \
+    libfmt-dev \
+    libgmp-dev \
+    libjpeg-dev \
+    libmpc-dev \
+    libx11-dev \
+    lsb-release \
+    m4 \
+    nano \
+    python3 \
+    python3-distutils \
+    python3-venv \
+    unzip \
+    vim \
+    wget \
+    wget2 \
+    zip \
+    zlib1g-dev
+
+RUN apt clean -y
+
+# Exawind GPU snapshot 
+WORKDIR /exawind-entry
+#RUN git clone --recursive https://github.com/sandialabs/spack-manager
+# Pre-merge fork
+#RUN git clone --recursive https://github.com/ajpowelsnl/spack-manager
+# Needed by "create-exawind-snapshot.sh"
+ENV SPACK_MANAGER_MACHINE=containergpucuda
+ENV CONTAINER_BUILD=gpucuda
+ENV SPACK_MANAGER=/exawind-entry/spack-manager
+
+#WORKDIR /exawind-entry/spack-manager
+
+# Pre-merge branch from ajpowelsnl/spack-manager fork
+#RUN git checkout gpucontainer
+
+# Snapshot will be generated upon running container
+#RUN echo "export SPACK_MANAGER=$SPACK_MANAGER" >> /etc/bash.bashrc && \
+#    echo "source $SPACK_MANAGER/start.sh && spack-start" >> /etc/bash.bashrc && \
+#    echo "spack external find" >> /etc/bash.bashrc && \
+#    echo "spack config add packages:all:target:[$uarch]" >> /etc/bash.bashrc && \
+#    echo "$SPACK_MANAGER/scripts/create-exawind-snapshot.sh" >> /etc/bash.bashrc && \
+#    echo "spack clean -a" >> /etc/bash.bashrc
+
+# Verify .bashrc
+# RUN ["/bin/bash", "-c", "tail -n 6 /etc/bash.bashrc"]
+
+WORKDIR /exawind-entry
+CMD [ "/bin/bash" ]

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -1,11 +1,11 @@
-MAINTAINER Philip Sakievich, Sandia National Laboratories <psakiev@sandia.gov>
-MAINTAINER Jon Rood, NREL <Jon.Rood@nrel.gov>
+LABEL maintainer="Philip Sakievich, Sandia National Laboratories <psakiev@sandia.gov>"
 
 # NVIDIA base images:  https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags
 
 ARG REGISTRY=nvcr.io/nvidia
 ARG IMAGE=cuda
-ARG TAG=11.8.0-devel-ubuntu22.04
+#ARG TAG=11.8.0-devel-ubuntu22.04
+ARG TAG=12.2.0-devel-ubuntu22.04
 
 FROM ${REGISTRY}/${IMAGE}:${TAG}
 
@@ -14,10 +14,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Install Spack Prereqs: https://spack.readthedocs.io/en/latest/getting_started.html#system-prerequisites
 
-RUN apt-get update -y && \
-    apt-get upgrade -y
+RUN apt-get update -yqq && \
+    apt-get upgrade -yqq
 
-RUN apt-get install -y \
+RUN apt-get install -yqq \
     autoconf \
     automake \
     bzip2 \
@@ -72,6 +72,7 @@ RUN apt clean -y
 
 # Exawind GPU snapshot 
 WORKDIR /exawind-entry
+#
 #RUN git clone --recursive https://github.com/sandialabs/spack-manager
 # Pre-merge fork
 RUN git clone --recursive https://github.com/ajpowelsnl/spack-manager
@@ -82,18 +83,45 @@ ENV SPACK_MANAGER=/exawind-entry/spack-manager
 
 WORKDIR /exawind-entry/spack-manager
 
+# Nota bene: commented code is needed, but does not work in container env
 # Pre-merge branch from ajpowelsnl/spack-manager fork
-RUN git checkout gpucontainer
+# RUN git checkout gpucontainer
+
+# Temp. code:  Use branch of Spack w/ patch
+# DOESN'T BUILD CORRECTLY
+#RUN cd spack
+#RUN git remote add amy_fork https://github.com/ajpowelsnl/spack.git
+#RUN git fetch amy_fork
+#RUN git checkout amy_fork/spack/patch_yaksa
+
 
 # Snapshot will be generated upon running container
-#RUN echo "export SPACK_MANAGER=$SPACK_MANAGER" >> /etc/bash.bashrc && \
-#    echo "source $SPACK_MANAGER/start.sh && spack-start" >> /etc/bash.bashrc && \
-#    echo "spack external find --all" >> /etc/bash.bashrc && \
-#    echo "$SPACK_MANAGER/scripts/create-exawind-snapshot.sh" >> /etc/bash.bashrc && \
-#    echo "spack clean -a" >> /etc/bash.bashrc
+RUN  echo "pwd" >> /etc/bash.bashrc && \
+     echo "cd spack" >> /etc/bash.bashrc && \
+     echo "git remote add amy_fork https://github.com/ajpowelsnl/spack.git" >> /etc/bash.bashrc && \
+     echo "git fetch amy_fork" >> /etc/bash.bashrc && \
+     echo "git checkout amy_fork/spack/patch_yaksa" >> /etc/bash.bashrc && \
+     echo "cd .." >> /etc/bash.bashrc && \
+     echo "pwd" >> /etc/bash.bashrc && \
+     echo "git checkout gpucontainer" >> /etc/bash.bashrc && \
+     echo "export SPACK_MANAGER=$SPACK_MANAGER" >> /etc/bash.bashrc && \
+     echo "source $SPACK_MANAGER/start.sh && spack-start" >> /etc/bash.bashrc && \
+     echo "spack external find --all" >> /etc/bash.bashrc && \
+     echo "$SPACK_MANAGER/scripts/create-exawind-snapshot.sh" >> /etc/bash.bashrc && \
+     echo "spack clean --all" >> /etc/bash.bashrc && \
+     echo "spack env activate -d snapshots/exawind/containergpucuda/$(date +%Y-%m-%d)" >> /etc/bash.bashrc && \
+     echo "spack load exawind" >> /etc/bash.bashrc
 
 # Verify .bashrc
 # RUN ["/bin/bash", "-c", "tail -n 6 /etc/bash.bashrc"]
+
+# Verify executable:
+#   66  spack env activate -d snapshots/exawind/containergpucuda/2023-11-01/
+#   67  spack load exawind
+#   68  which exawind
+#   69  exawind --help
+
+
 
 #WORKDIR /exawind-entry
 CMD [ "/bin/bash" ]

--- a/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
+++ b/hpc_containers/exawind_container_gpucuda/Dockerfile-containergpucuda
@@ -43,6 +43,8 @@ RUN apt-get install -y \
     libbz2-dev \
     libffi-dev \
     libfmt-dev \
+    libgdbm-dev \
+    libgdbm6 \
     libgmp-dev \
     libhwloc-common \
     libhwloc-dev \

--- a/scripts/create-exawind-snapshot.sh
+++ b/scripts/create-exawind-snapshot.sh
@@ -53,7 +53,6 @@ elif [[ "${SPACK_MANAGER_MACHINE}" == "perlmutter" ]]; then
   NUM_CORES=8
   cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "containergpucuda" ]]; then
-  NUM_CORES=8
   cmd "nice -n19 spack -d manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "snl-hpc" ]]; then
   # TODO we should probably launch the install through slurm and exit on this one

--- a/scripts/create-exawind-snapshot.sh
+++ b/scripts/create-exawind-snapshot.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -l
+    hwloc-nox \
+    libhwloc-dev \
+    libhwloc15 \
 #
 # Copyright (c) 2022, National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
@@ -50,6 +53,9 @@ elif [[ "${SPACK_MANAGER_MACHINE}" == "summit" ]]; then
   NUM_CORES=8
   cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu exawind%gcc+hypre~cuda"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "perlmutter" ]]; then
+  NUM_CORES=8
+  cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
+elif [[ "${SPACK_MANAGER_MACHINE}" == "containergpucuda" ]]; then
   NUM_CORES=8
   cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "snl-hpc" ]]; then

--- a/scripts/create-exawind-snapshot.sh
+++ b/scripts/create-exawind-snapshot.sh
@@ -54,6 +54,7 @@ elif [[ "${SPACK_MANAGER_MACHINE}" == "perlmutter" ]]; then
   cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "containergpucuda" ]]; then
   cmd "nice -n19 spack -d manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
+  NUM_CORES=8
 elif [[ "${SPACK_MANAGER_MACHINE}" == "snl-hpc" ]]; then
   # TODO we should probably launch the install through slurm and exit on this one
   cmd "nice -n19 spack manager snapshot -s exawind+hypre+openfast amr-wind+hypre+openfast"

--- a/scripts/create-exawind-snapshot.sh
+++ b/scripts/create-exawind-snapshot.sh
@@ -1,7 +1,4 @@
-#!/bin/bash -l
-    hwloc-nox \
-    libhwloc-dev \
-    libhwloc15 \
+#!/bin/bash
 #
 # Copyright (c) 2022, National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
@@ -57,7 +54,7 @@ elif [[ "${SPACK_MANAGER_MACHINE}" == "perlmutter" ]]; then
   cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "containergpucuda" ]]; then
   NUM_CORES=8
-  cmd "nice -n19 spack manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
+  cmd "nice -n19 spack -d manager snapshot -m -s exawind%gcc+hypre+cuda+amr_wind_gpu+nalu_wind_gpu"
 elif [[ "${SPACK_MANAGER_MACHINE}" == "snl-hpc" ]]; then
   # TODO we should probably launch the install through slurm and exit on this one
   cmd "nice -n19 spack manager snapshot -s exawind+hypre+openfast amr-wind+hypre+openfast"

--- a/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/find_machine.py
@@ -97,6 +97,9 @@ machine_list = {
     "perlmutter": MachineData(
         lambda: os.environ["NERSC_HOST"] == "perlmutter", "perlmutter-p1.nersc.gov"
     ),
+    "containergpucuda": MachineData(
+        lambda: os.environ["CONTAINER_BUILD"] == "gpucuda", "containgpucuda.nodomain.gov"
+    ),
     # General
     "darwin": MachineData(lambda: sys.platform == "darwin", "darwin.nodomain.gov"),
 }


### PR DESCRIPTION
The proposed code specifies a spack-manager-based GPU-capable container on NERSC science platforms.


- Use [NERSC Container Technology](https://docs.nersc.gov/development/podman-hpc/overview/)

## Build

```
podman-hpc build --no-cache -t <TAG_NAME> -f Dockerfile-containergpucuda .

```

## Run


```
podman-hpc run --rm --gpu -it <TAG_NAME>

```

## Expected Output

```
root@8953e3033a99:/exawind-entry/spack-manager# which exawind
/exawind-entry/spack-manager/snapshots/exawind/containergpucuda/2023-11-03/opt/linux-ubuntu22.04-zen3/gcc-11.4.0/exawind-git.d3c1aa4656fc3c6eccaec8c684671c82a3895172=multiphase-fyborjcfgnruxcks2vwzrc4guyw5toew/bin/exawind
root@8953e3033a99:/exawind-entry/spack-manager# exawind --help
usage: exawind [--awind NPROCS] [--nwind NPROCS] input_file
	-h,--help		Show this help message
	--awind NPROCS		Number of ranks for AMR-Wind (default = all ranks)
	--nwind NPROCS		Number of ranks for Nalu-Wind (default = all ranks)
```


## Helpful Hints
- After exiting a container, you must build the container again using a new tag name. 
- If using non-NERSC machines, Docker can be used instead of `podman-hpc`
- Be aware that `spack-manager` depends on a pinned version of Spack, a point of configure / build / runtime fragility 
