### PR TITLE
Remove modifications to PYTHONPATH

### DIFF
--- a/scripts/spack_start.sh
+++ b/scripts/spack_start.sh
@@ -12,7 +12,6 @@ if ! $(type '_spack_start_called' 2>/dev/null | grep -q 'function'); then
   export SPACK_ROOT=${SPACK_MANAGER}/spack
   export SPACK_USER_CACHE_PATH=${SPACK_MANAGER}/.cache
   export SPACK_USER_CONFIG_PATH=${SPACK_MANAGER}/.spack
-  export PYTHONPATH=${PYTHONPATH}:${SPACK_MANAGER}/scripts:${SPACK_MANAGER}/spack-scripting/scripting/cmd:${SPACK_MANAGER}/spack-scripting/scripting
   source ${SPACK_ROOT}/share/spack/setup-env.sh
 
   # Clean Spack misc caches

--- a/spack-scripting/scripting/cmd/__init__.py
+++ b/spack-scripting/scripting/cmd/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2022, National Technology & Engineering Solutions of Sandia,
+# LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# This software is released under the BSD 3-clause license. See LICENSE file
+# for more details.

--- a/spack-scripting/scripting/cmd/manager.py
+++ b/spack-scripting/scripting/cmd/manager.py
@@ -7,15 +7,16 @@
 
 import sys
 
-import manager_cmds.create_dev_env
-import manager_cmds.create_env
-import manager_cmds.develop
-import manager_cmds.external
-import manager_cmds.find_machine
-import manager_cmds.pin
-import manager_cmds.snapshot
+from manager.cmd.manager_cmds import create_dev_env
+from manager.cmd.manager_cmds import create_env
+from manager.cmd.manager_cmds import develop
+from manager.cmd.manager_cmds import external
+from manager.cmd.manager_cmds import find_machine
+from manager.cmd.manager_cmds import pin
+from manager.cmd.manager_cmds import snapshot
 
 if sys.version_info[0] < 3:
+    # TODO use tty
     print("spack-manager commands only support python 3")
     exit(1)
 
@@ -28,13 +29,13 @@ _subcommands = {}
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="spack-manager commands", dest="manager_command")
-    manager_cmds.create_env.add_command(sp, _subcommands)
-    manager_cmds.create_dev_env.add_command(sp, _subcommands)
-    manager_cmds.develop.add_command(sp, _subcommands)
-    manager_cmds.find_machine.add_command(sp, _subcommands)
-    manager_cmds.external.add_command(sp, _subcommands)
-    manager_cmds.pin.add_command(sp, _subcommands)
-    manager_cmds.snapshot.add_command(sp, _subcommands)
+    create_env.add_command(sp, _subcommands)
+    create_dev_env.add_command(sp, _subcommands)
+    develop.add_command(sp, _subcommands)
+    find_machine.add_command(sp, _subcommands)
+    external.add_command(sp, _subcommands)
+    pin.add_command(sp, _subcommands)
+    snapshot.add_command(sp, _subcommands)
 
 
 def manager(parser, args):

--- a/spack-scripting/scripting/cmd/manager.py
+++ b/spack-scripting/scripting/cmd/manager.py
@@ -7,13 +7,13 @@
 
 import sys
 
-from manager.cmd.manager_cmds import create_dev_env
-from manager.cmd.manager_cmds import create_env
-from manager.cmd.manager_cmds import develop
-from manager.cmd.manager_cmds import external
-from manager.cmd.manager_cmds import find_machine
-from manager.cmd.manager_cmds import pin
-from manager.cmd.manager_cmds import snapshot
+from scripting.cmd.manager_cmds import create_dev_env
+from scripting.cmd.manager_cmds import create_env
+from scripting.cmd.manager_cmds import develop
+from scripting.cmd.manager_cmds import external
+from scripting.cmd.manager_cmds import find_machine
+from scripting.cmd.manager_cmds import pin
+from scripting.cmd.manager_cmds import snapshot
 
 if sys.version_info[0] < 3:
     # TODO use tty

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -7,8 +7,8 @@
 
 import argparse
 
-import manager_cmds.create_env as create_env
-import manager_cmds.develop
+import manager.cmd.manager_cmds.create_env as create_env
+import manager.cmd.manager_cmds.develop as mgr_develop
 
 import spack.cmd
 import spack.environment as ev
@@ -20,9 +20,9 @@ def develop(args):
     """
     parser = argparse.ArgumentParser("develop")
     sub_parser = parser.add_subparsers()
-    manager_cmds.develop.add_command(sub_parser, {})
+    mgr_develop.add_command(sub_parser, {})
     args = parser.parse_args(["develop", *args])
-    manager_cmds.develop.manager_develop(parser, args)
+    mgr_develop.manager_develop(parser, args)
 
 
 def create_dev_env(parser, args):

--- a/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_dev_env.py
@@ -7,8 +7,8 @@
 
 import argparse
 
-import manager.cmd.manager_cmds.create_env as create_env
-import manager.cmd.manager_cmds.develop as mgr_develop
+import scripting.cmd.manager_cmds.create_env as create_env
+import scripting.cmd.manager_cmds.develop as mgr_develop
 
 import spack.cmd
 import spack.environment as ev

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -12,10 +12,10 @@ on a given machine
 
 import os
 
-import manager_cmds.find_machine as fm
-from environment_utils import SpackManagerEnvironmentManifest
-from manager_cmds.find_machine import find_machine
-from manager_cmds.includes_creator import IncludesCreator
+import manager.cmd.manager_cmds.find_machine as fm
+from manager.environment_utils import SpackManagerEnvironmentManifest
+from manager.cmd.manager_cmds.find_machine import find_machine
+from manager.cmd.manager_cmds.includes_creator import IncludesCreator
 
 import spack
 import spack.cmd

--- a/spack-scripting/scripting/cmd/manager_cmds/create_env.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/create_env.py
@@ -12,10 +12,10 @@ on a given machine
 
 import os
 
-import manager.cmd.manager_cmds.find_machine as fm
+import scripting.cmd.manager_cmds.find_machine as fm
 from manager.environment_utils import SpackManagerEnvironmentManifest
-from manager.cmd.manager_cmds.find_machine import find_machine
-from manager.cmd.manager_cmds.includes_creator import IncludesCreator
+from scripting.cmd.manager_cmds.find_machine import find_machine
+from scripting.cmd.manager_cmds.includes_creator import IncludesCreator
 
 import spack
 import spack.cmd

--- a/spack-scripting/scripting/cmd/manager_cmds/external.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/external.py
@@ -9,8 +9,8 @@ import os
 import re
 from datetime import datetime
 
-from environment_utils import SpackManagerEnvironmentManifest
-from manager_utils import base_extension, pruned_spec_string
+from manager.environment_utils import SpackManagerEnvironmentManifest
+from manager.manager_utils import base_extension, pruned_spec_string
 
 import llnl.util.tty as tty
 

--- a/spack-scripting/scripting/cmd/manager_cmds/pin.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/pin.py
@@ -8,7 +8,7 @@
 """
 Functions for snapshot creation that are added here to be testable
 """
-from manager_utils import command, pruned_spec_string
+from manager.manager_utils import command, pruned_spec_string
 
 import llnl.util.tty as tty
 

--- a/spack-scripting/scripting/cmd/manager_cmds/snapshot.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/snapshot.py
@@ -7,8 +7,8 @@
 import os
 
 from manager.environment_utils import SpackManagerEnvironmentManifest
-from manager.cmd.manager_cmds.create_env import create_env
-from manager.cmd.manager_cmds.pin import pin_env
+from scripting.cmd.manager_cmds.create_env import create_env
+from scripting.cmd.manager_cmds.pin import pin_env
 from manager.manager_utils import path_extension
 
 import spack.cmd.install

--- a/spack-scripting/scripting/cmd/manager_cmds/snapshot.py
+++ b/spack-scripting/scripting/cmd/manager_cmds/snapshot.py
@@ -6,10 +6,10 @@
 # for more details.
 import os
 
-from environment_utils import SpackManagerEnvironmentManifest
-from manager_cmds.create_env import create_env
-from manager_cmds.pin import pin_env
-from manager_utils import path_extension
+from manager.environment_utils import SpackManagerEnvironmentManifest
+from manager.cmd.manager_cmds.create_env import create_env
+from manager.cmd.manager_cmds.pin import pin_env
+from manager.manager_utils import path_extension
 
 import spack.cmd.install
 import spack.environment as ev

--- a/spack-scripting/tests/test_create_dev_env.py
+++ b/spack-scripting/tests/test_create_dev_env.py
@@ -14,7 +14,7 @@ import spack.main
 manager = spack.main.SpackCommand("manager")
 
 
-@patch("manager_cmds.create_dev_env.develop")
+@patch("scripting.cmd.manager_cmds.create_dev_env.develop")
 def test_allSpecsCallSpackDevelop(mock_dev, tmpdir):
     with tmpdir.as_cwd():
         manager("create-dev-env", "-s", "amr-wind@main", "nalu-wind@master", "exawind@master")
@@ -27,13 +27,13 @@ def test_allSpecsCallSpackDevelop(mock_dev, tmpdir):
 
 def test_newEnvironmentIsCreated(tmpdir):
     with tmpdir.as_cwd():
-        with patch("manager_cmds.create_dev_env.develop"):
+        with patch("scripting.cmd.manager_cmds.create_dev_env.develop"):
             manager("create-dev-env", "-s", "amr-wind@main", "nalu-wind@master", "exawind@master")
         assert os.path.isfile(tmpdir.join("spack.yaml"))
         assert os.path.isfile(tmpdir.join("include.yaml"))
 
 
-@patch("manager_cmds.create_dev_env.develop")
+@patch("scripting.cmd.manager_cmds.create_dev_env.develop")
 def test_newEnvironmentKeepingUserSpecifiedYAML(mock_dev, tmpdir):
     with tmpdir.as_cwd():
         amr_path = tmpdir.join("test_amr-wind")
@@ -85,7 +85,7 @@ def test_newEnvironmentKeepingUserSpecifiedYAML(mock_dev, tmpdir):
         )
 
 
-@patch("manager_cmds.create_dev_env.develop")
+@patch("scripting.cmd.manager_cmds.create_dev_env.develop")
 def test_nonConcreteSpecsDontGetCloned(mock_dev, tmpdir):
     with tmpdir.as_cwd():
         manager(
@@ -98,7 +98,7 @@ def test_nonConcreteSpecsDontGetCloned(mock_dev, tmpdir):
         assert "amr-wind" in e.manifest.pristine_yaml_content["spack"]["specs"]
 
 
-@patch("manager_cmds.create_dev_env.develop")
+@patch("scripting.cmd.manager_cmds.create_dev_env.develop")
 def test_noSpecsIsNotAnErrorGivesBlankEnv(mock_develop, tmpdir):
     with tmpdir.as_cwd():
         manager("create-dev-env", "-d", tmpdir.strpath)

--- a/spack-scripting/tests/test_create_env.py
+++ b/spack-scripting/tests/test_create_env.py
@@ -8,7 +8,7 @@
 import os
 from tempfile import TemporaryDirectory
 
-import manager_cmds.create_env as create_env
+import scripting.cmd.manager_cmds.create_env as create_env
 import pytest
 
 import spack.environment as env

--- a/spack-scripting/tests/test_develop.py
+++ b/spack-scripting/tests/test_develop.py
@@ -19,16 +19,16 @@ manager = spack.main.SpackCommand("manager")
 
 @pytest.mark.usefixtures("mutable_mock_env_path", "mock_packages", "mock_fetch")
 class TestSpackManagerDevelop(object):
-    @patch("manager_cmds.develop.spack_develop.develop")
+    @patch("scripting.cmd.manager_cmds.develop.spack_develop.develop")
     def test_spackManagerDevelopCallsSpackDevelop(self, mock_develop):
         env("create", "test")
         with ev.read("test"):
             manager("develop", "mpich@=1.0")
             mock_develop.assert_called_once()
 
-    @patch("manager_cmds.develop.spack_develop.develop")
-    @patch("manager_cmds.develop.git_clone")
-    @patch("manager_cmds.develop.git_remote_add")
+    @patch("scripting.cmd.manager_cmds.develop.spack_develop.develop")
+    @patch("scripting.cmd.manager_cmds.develop.git_clone")
+    @patch("scripting.cmd.manager_cmds.develop.git_remote_add")
     @pytest.mark.parametrize("all_branches", [True, False])
     @pytest.mark.parametrize("shallow", [True, False])
     @pytest.mark.parametrize("add_remote", [True, False])

--- a/spack-scripting/tests/test_external.py
+++ b/spack-scripting/tests/test_external.py
@@ -8,10 +8,10 @@
 import os
 from unittest.mock import patch
 
-import manager_cmds
-import manager_cmds.external
+import scripting.cmd.manager_cmds
+import scripting.cmd.manager_cmds.external
 import pytest
-from manager_utils import pruned_spec_string
+from manager.manager_utils import pruned_spec_string
 
 import spack.environment as ev
 import spack.main
@@ -111,7 +111,7 @@ def test_errorsIfThereIsNoView(tmpdir):
         args = ParserMock(ext_env)
         with pytest.raises(SystemExit):
             with ev.Environment("test"):
-                manager_cmds.external.external(None, args)
+                scripting.cmd.manager_cmds.external.external(None, args)
 
 
 class ExtPackage:
@@ -145,11 +145,11 @@ def evaluate_external(tmpdir, yaml_file):
     with ev.Environment("test") as e:
         args = ParserMock(ext_path, merge=True)
         with patch(
-            "manager_cmds.external.write_spec",
-            return_value=str(ExtPackage("cmake", "cmake@3.20.0", "/path/top/some/view")),
+            "scripting.cmd.manager_cmds.external.write_spec",
+            rscripting.cmd.eturn_value=str(ExtPackage("cmake", "cmake@3.20.0", "/path/top/some/view")),
         ) as mock_write:
-            manager_cmds.external.external(None, args)
-        # check that the include entry was added to the spack.yaml
+            scripting.cmd.manager_cmds.external.external(None, args)
+        # chscripting.cmd.eck that the include entry was added to the spack.yaml
         assert mock_write.called_once()
         includes = config_dict(e.yaml).get("include", [])
         assert 1 == len(includes)

--- a/spack-scripting/tests/test_find_machine.py
+++ b/spack-scripting/tests/test_find_machine.py
@@ -6,7 +6,7 @@
 # for more details.
 
 import pytest
-from manager_cmds.find_machine import is_cee, is_jlse, is_snl_hpc
+from scripting.cmd.manager_cmds.find_machine import is_cee, is_jlse, is_snl_hpc
 
 
 @pytest.mark.parametrize("test_function", [is_cee, is_snl_hpc, is_jlse])

--- a/spack-scripting/tests/test_pin.py
+++ b/spack-scripting/tests/test_pin.py
@@ -5,7 +5,7 @@
 # This software is released under the BSD 3-clause license. See LICENSE file
 # for more details.
 
-from manager_cmds.pin import pin_graph
+from scripting.cmd.manager_cmds.pin import pin_graph
 
 from spack.spec import Spec
 from spack.version import GitVersion

--- a/spack-scripting/tests/test_spack_manager_environment_manifest.py
+++ b/spack-scripting/tests/test_spack_manager_environment_manifest.py
@@ -5,7 +5,7 @@
 # This software is released under the BSD 3-clause license. See LICENSE file
 # for more details.
 
-from environment_utils import SpackManagerEnvironmentManifest as smem
+from manager.environment_utils import SpackManagerEnvironmentManifest as smem
 
 import spack.util.spack_yaml as syaml
 


### PR DESCRIPTION
Working toward making spack-manager a true spack plugin, we need to remove all shell modifications that we currently use.

PYTHONPATH is the obvious one to start.

Directory refactors will be started next, but likely on a dev branch so we don't interrupt users.