### PR TITLE
Fix bugs in lock diff

### DIFF
--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -30,6 +30,7 @@ def setup_parser_args(subparser):
         "--skip-package-diffs",
         "-s",
         nargs="+",
+        default=[],
         help="packages to skip package hash diffs",
         required=False,
     )
@@ -104,7 +105,7 @@ def lock_diff(parser, args):
                 diff_msg += "package hash change - Old: {} New: {}".format(
                     old_spec.package_hash(), new_spec.package_hash()
                 )
-                if new_spec.name not in args.skip_package_diffs:
+                if spec.name not in args.skip_package_diffs:
                     unacceptable_changes = True
             else:
                 # something else must have changed in concretization that


### PR DESCRIPTION
The lock-diff command came out of a project that was using it in a specific way. Several bugs have been found from more general use.

Outstanding issues:

- [ ] Multiple specs: this tool was mainly written for unified env's but compilers as deps is leading to a lot more repeated specs in the graph.  Need better logic/generalization for diffing the graph
- [ ] Testing: add some basic unit-tests so this can be expanded