### PR TITLE
Fix failing CI on analyze

### DIFF
--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -7,11 +7,11 @@
 
 import sys
 
-_analyse_imports = True
+_analyze_imports = True
 try:
     import spack.extensions.manager.manager_cmds.analyze as analyze
 except:
-    _analyse_imports = False
+    _analyze_imports = False
 import spack.extensions.manager.manager_cmds.binary_finder as binary_finder
 import spack.extensions.manager.manager_cmds.cache_query as cache_query
 import spack.extensions.manager.manager_cmds.cli_config as cli_config

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -7,7 +7,11 @@
 
 import sys
 
-import spack.extensions.manager.manager_cmds.analyze as analyze
+_analyse_imports = True
+try:
+    import spack.extensions.manager.manager_cmds.analyze as analyze
+except:
+    _analyse_imports = False
 import spack.extensions.manager.manager_cmds.binary_finder as binary_finder
 import spack.extensions.manager.manager_cmds.cache_query as cache_query
 import spack.extensions.manager.manager_cmds.cli_config as cli_config
@@ -39,8 +43,8 @@ def setup_parser(subparser):
     cli_config.cli_commands["add"](sp, _subcommands)
     cli_config.cli_commands["remove"](sp, _subcommands)
     cli_config.cli_commands["list"](sp, _subcommands)
-
-    analyze.add_command(sp, _subcommands)
+    if _analyze_imports:
+        analyze.add_command(sp, _subcommands)
     binary_finder.add_command(sp, _subcommands)
     cache_query.add_command(sp, _subcommands)
     create_env.add_command(sp, _subcommands)

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -20,10 +20,11 @@ import spack.extensions.manager.manager_cmds.location as location
 import spack.extensions.manager.manager_cmds.lock_diff as lock_diff
 import spack.extensions.manager.manager_cmds.make as make
 import spack.extensions.manager.manager_cmds.pin as pin
+
 try:
     import spack.extensions.manager.manager_cmds.analyze as analyze
     _analyze_imports = True
-except: ImportError
+except ImportError:
     _analyze_imports = False
 
 if sys.version_info < (3, 8):

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -7,11 +7,6 @@
 
 import sys
 
-_analyze_imports = True
-try:
-    import spack.extensions.manager.manager_cmds.analyze as analyze
-except:
-    _analyze_imports = False
 import spack.extensions.manager.manager_cmds.binary_finder as binary_finder
 import spack.extensions.manager.manager_cmds.cache_query as cache_query
 import spack.extensions.manager.manager_cmds.cli_config as cli_config
@@ -25,6 +20,11 @@ import spack.extensions.manager.manager_cmds.location as location
 import spack.extensions.manager.manager_cmds.lock_diff as lock_diff
 import spack.extensions.manager.manager_cmds.make as make
 import spack.extensions.manager.manager_cmds.pin as pin
+try:
+    import spack.extensions.manager.manager_cmds.analyze as analyze
+    _analyze_imports = True
+except: ImportError
+    _analyze_imports = False
 
 if sys.version_info < (3, 8):
     print("spack-manager commands only supported in python 3.8 and higher")

--- a/manager/manager_cmds/analyze.py
+++ b/manager/manager_cmds/analyze.py
@@ -216,7 +216,6 @@ def analyze(parser, args):
     else:
         visitor = OmitSpecsVisitor([])
 
-
     stats = compute_dag_stats(specs, visitor)
 
     if args.stats:


### PR DESCRIPTION
Analyze relies on an import from a module that wasn't around in 0.20