### PR TITLE
Refactor imports to work with python3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,41 +13,6 @@ on:
   - cron: "0 8 * * *"
 
 jobs:
-  legacy-unit-tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7]
-        spack-version: [develop]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      # uses: actions/setup-python@v5
-      # mirror spack-core
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pip setuptools pytest pytest-xdist pytest-cov
-          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
-    - name: Checkout Spack
-      uses: actions/checkout@v4
-      with:
-        repository: spack/spack
-        ref: ${{ matrix.spack-version }}
-        path: spack
-    - name: Setup Spack ${{ matrix.spack-version }}
-      run: echo "$PWD/spack/bin" >> "$GITHUB_PATH"
-    - name: Install extension
-      run: |
-        ./install.py --scope site
-        spack manager --help
-    - name: Run unit tests
-      run: |
-        . spack/share/spack/setup-env.sh
-        spack unit-test --extension manager
   unit-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.12]
+        python-version: [3.6, 3.8, 3.9, 3.12]
         spack-version: [develop]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,47 @@ on:
   - cron: "0 8 * * *"
 
 jobs:
+  legacy-unit-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7]
+        spack-version: [develop]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      # uses: actions/setup-python@v5
+      # mirror spack-core
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip setuptools pytest pytest-xdist pytest-cov
+          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
+    - name: Checkout Spack
+      uses: actions/checkout@v4
+      with:
+        repository: spack/spack
+        ref: ${{ matrix.spack-version }}
+        path: spack
+    - name: Setup Spack ${{ matrix.spack-version }}
+      run: echo "$PWD/spack/bin" >> "$GITHUB_PATH"
+    - name: Install extension
+      run: |
+        ./install.py --scope site
+        spack manager --help
+    - name: Run unit tests
+      run: |
+        . spack/share/spack/setup-env.sh
+        spack unit-test --extension manager
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.8, 3.9, 3.12]
+        python-version: [3.8, 3.9, 3.12]
         spack-version: [develop]
     steps:
     - uses: actions/checkout@v4

--- a/check.py
+++ b/check.py
@@ -16,7 +16,7 @@ import sys
 
 def check_spack_manager_requirements():
     if sys.version_info < (3, 8):
-        raise ValueError("Spack-Manager requires Python 3.8 or higher.")
+        print("Spack-Manager requires Python 3.8 or higher.")
 
 
 if __name__ == "__main__":

--- a/check.py
+++ b/check.py
@@ -15,8 +15,8 @@ import sys
 
 
 def check_spack_manager_requirements():
-    if sys.version_info < (3, 8):
-        print("Spack-Manager requires Python 3.8 or higher.")
+    if sys.version_info < (3, 6):
+        raise ValueError("Spack-Manager requires Python 3.6 or higher.")
 
 
 if __name__ == "__main__":

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -7,29 +7,27 @@
 
 import sys
 
-import spack.extensions.manager.manager_cmds.binary_finder as binary_finder
-import spack.extensions.manager.manager_cmds.cache_query as cache_query
-import spack.extensions.manager.manager_cmds.cli_config as cli_config
-import spack.extensions.manager.manager_cmds.create_dev_env as create_dev_env
-import spack.extensions.manager.manager_cmds.create_env as create_env
-import spack.extensions.manager.manager_cmds.develop as develop
-import spack.extensions.manager.manager_cmds.external as external
-import spack.extensions.manager.manager_cmds.find_machine as find_machine
-import spack.extensions.manager.manager_cmds.include as include
-import spack.extensions.manager.manager_cmds.location as location
-import spack.extensions.manager.manager_cmds.lock_diff as lock_diff
-import spack.extensions.manager.manager_cmds.make as make
-import spack.extensions.manager.manager_cmds.pin as pin
+from ..manager_cmds import binary_finder as binary_finder
+from ..manager_cmds import cache_query as cache_query
+from ..manager_cmds import cli_config as cli_config
+from ..manager_cmds import create_dev_env as create_dev_env
+from ..manager_cmds import create_env as create_env
+from ..manager_cmds import develop as develop
+from ..manager_cmds import external as external
+from ..manager_cmds import find_machine as find_machine
+from ..manager_cmds import include as include
+from ..manager_cmds import location as location
+from ..manager_cmds import lock_diff as lock_diff
+from ..manager_cmds import make as make
+from ..manager_cmds import pin as pin
 
 try:
-    import spack.extensions.manager.manager_cmds.analyze as analyze
+    from .manager_cmds import analyze as analyze
+
     _analyze_imports = True
 except ImportError:
     _analyze_imports = False
 
-if sys.version_info < (3, 8):
-    print("spack-manager commands only supported in python 3.8 and higher")
-    exit(1)
 
 description = "commands that are specific to spack-manager"
 section = "spack-manager"

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -5,22 +5,24 @@
 # This software is released under the BSD 3-clause license. See LICENSE file
 # for more details.
 
-from ..manager_cmds import binary_finder as binary_finder
-from ..manager_cmds import cache_query as cache_query
-from ..manager_cmds import cli_config as cli_config
-from ..manager_cmds import create_dev_env as create_dev_env
-from ..manager_cmds import create_env as create_env
-from ..manager_cmds import develop as develop
-from ..manager_cmds import external as external
-from ..manager_cmds import find_machine as find_machine
-from ..manager_cmds import include as include
-from ..manager_cmds import location as location
-from ..manager_cmds import lock_diff as lock_diff
-from ..manager_cmds import make as make
-from ..manager_cmds import pin as pin
+from ..manager_cmds import (
+    binary_finder,
+    cache_query,
+    cli_config,
+    create_dev_env,
+    create_env,
+    develop,
+    external,
+    find_machine,
+    include,
+    location,
+    lock_diff,
+    make,
+    pin,
+)
 
 try:
-    from .manager_cmds import analyze as analyze
+    from .manager_cmds import analyze
 
     _analyze_imports = True
 except ImportError:

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -5,8 +5,6 @@
 # This software is released under the BSD 3-clause license. See LICENSE file
 # for more details.
 
-import sys
-
 from ..manager_cmds import binary_finder as binary_finder
 from ..manager_cmds import cache_query as cache_query
 from ..manager_cmds import cli_config as cli_config

--- a/manager/manager_cmds/analyze.py
+++ b/manager/manager_cmds/analyze.py
@@ -60,17 +60,13 @@ def setup_parser_args(subparser):
         help="clip the graph at nodes that satisfy these specs",
     )
     visitor_types.add_argument(
-        "--require-attribute",
-        "-r",
-        help="only include packages that have this package attribute",
+        "--require-attribute", "-r", help="only include packages that have this package attribute"
     )
     subparser.add_argument(
         "--stats", action="store_true", help="display stats for graph build/install"
     )
     subparser.add_argument(
-        "--graph",
-        action="store_true",
-        help="generate a dot file of the graph requested",
+        "--graph", action="store_true", help="generate a dot file of the graph requested"
     )
     subparser.add_argument(
         "--scale-nodes",
@@ -79,17 +75,12 @@ def setup_parser_args(subparser):
         help="scale graph nodes relative to the mean install time",
     )
     subparser.add_argument(
-        "--color",
-        "-c",
-        action="store_true",
-        help="color graph nodes based on the time to build",
+        "--color", "-c", action="store_true", help="color graph nodes based on the time to build"
     )
 
 
 def traverse_nodes_with_visitor(specs, visitor):
-    traverse.traverse_breadth_first_with_visitor(
-        specs, traverse.CoverNodesVisitor(visitor)
-    )
+    traverse.traverse_breadth_first_with_visitor(specs, traverse.CoverNodesVisitor(visitor))
     return visitor.accepted
 
 
@@ -169,10 +160,7 @@ class StatsGraphBuilder(DotGraphBuilder):
         scale_str = f"width={x} height={y} fixedsize=true fontsize={fontsize}"
         color_str = f'fillcolor="{color_compute if self.to_color else"lightblue"}"'
 
-        return (
-            node.dag_hash(),
-            f'[label="{node.format("{name}")}", {color_str}, {scale_str}]',
-        )
+        return (node.dag_hash(), f'[label="{node.format("{name}")}", {color_str}, {scale_str}]')
 
     def edge_entry(self, edge):
         return (edge.parent.dag_hash(), edge.spec.dag_hash(), None)

--- a/manager/manager_cmds/cli_config.py
+++ b/manager/manager_cmds/cli_config.py
@@ -9,8 +9,8 @@
 Implementations for interacting and editing the spack-manager YAML config from the
 command line interface
 """
-import spack.extensions.manager as manager
-import spack.extensions.manager.projects as projects
+from ... import manager
+from .. import projects
 
 
 def _impl_add(parser, args):

--- a/manager/manager_cmds/create_dev_env.py
+++ b/manager/manager_cmds/create_dev_env.py
@@ -9,8 +9,8 @@ import argparse
 
 import spack.cmd
 import spack.environment as ev
-import spack.extensions.manager.manager_cmds.create_env as create_env
-import spack.extensions.manager.manager_cmds.develop as mdevelop
+from . import create_env
+from . import develop as mdevelop
 
 
 def develop(*args):

--- a/manager/manager_cmds/create_dev_env.py
+++ b/manager/manager_cmds/create_dev_env.py
@@ -9,6 +9,7 @@ import argparse
 
 import spack.cmd
 import spack.environment as ev
+
 from . import create_env
 from . import develop as mdevelop
 

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -14,7 +14,7 @@ import spack.util.executable
 from spack.cmd.develop import develop as s_develop
 from spack.cmd.develop import setup_parser as s_setup_parser
 from spack.error import SpackError
-from spack.extensions.manager.manager_utils import canonicalize_path
+from ..manager_utils import canonicalize_path
 
 
 def git_clone(branch, repo, path, shallow, all_branches):
@@ -117,7 +117,6 @@ def manager_develop(parser, args):
         git_clone(branch, repo, path, args.shallow, args.all_branches)
         args.clone = False
 
-    breakpoint()
     s_develop(None, args)
 
     if args.add_remote:

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -14,6 +14,7 @@ import spack.util.executable
 from spack.cmd.develop import develop as s_develop
 from spack.cmd.develop import setup_parser as s_setup_parser
 from spack.error import SpackError
+
 from ..manager_utils import canonicalize_path
 
 

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -117,6 +117,7 @@ def manager_develop(parser, args):
         git_clone(branch, repo, path, args.shallow, args.all_branches)
         args.clone = False
 
+    breakpoint()
     s_develop(None, args)
 
     if args.add_remote:

--- a/manager/manager_cmds/find_machine.py
+++ b/manager/manager_cmds/find_machine.py
@@ -7,7 +7,7 @@
 
 import os
 
-import spack.extensions.manager.projects as m_proj
+from .. import projects as m_proj
 
 
 def machine_defined(name):

--- a/manager/manager_cmds/include.py
+++ b/manager/manager_cmds/include.py
@@ -8,8 +8,9 @@
 import os
 import sys
 
-from .. import projects
 import spack.llnl.util.tty as tty
+
+from .. import projects
 from .find_machine import find_machine, machine_defined
 from .includes_creator import IncludesCreator
 

--- a/manager/manager_cmds/include.py
+++ b/manager/manager_cmds/include.py
@@ -8,10 +8,10 @@
 import os
 import sys
 
-import spack.extensions.manager.projects as projects
+from .. import projects
 import spack.llnl.util.tty as tty
-from spack.extensions.manager.manager_cmds.find_machine import find_machine, machine_defined
-from spack.extensions.manager.manager_cmds.includes_creator import IncludesCreator
+from .find_machine import find_machine, machine_defined
+from .includes_creator import IncludesCreator
 
 
 def include_creator(parser, args):

--- a/manager/projects.py
+++ b/manager/projects.py
@@ -6,9 +6,10 @@
 
 import os
 
+import spack.llnl.util.lang
+
 # from .. import manager
 from . import config_yaml
-import spack.llnl.util.lang
 from .manager_utils import canonicalize_path
 
 DETECTION_SCRIPT = "find-{n}.py"

--- a/manager/projects.py
+++ b/manager/projects.py
@@ -6,9 +6,10 @@
 
 import os
 
-import spack.extensions.manager as manager
+# from .. import manager
+from . import config_yaml
 import spack.llnl.util.lang
-from spack.extensions.manager.manager_utils import canonicalize_path
+from .manager_utils import canonicalize_path
 
 DETECTION_SCRIPT = "find-{n}.py"
 DETECTION_MODULE = "find_{n}"
@@ -89,7 +90,7 @@ class Project:
 
 def get_projects(selector=None):
     projects = []
-    projects_node = manager.config_yaml["spack-manager"]["projects"]
+    projects_node = config_yaml["spack-manager"]["projects"]
     for i, path in enumerate(projects_node):
         p = Project(path)
         if selector:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-import spack.extensions.manager as manager
+import manager
 from spack.test.conftest import *  # noqa: F401 F403
 
 _test_root = os.path.dirname(__file__)
@@ -25,6 +25,7 @@ class Patcher(object):
     """
 
     def __init__(self, patch_func=None):
+        breakpoint()
         self.args = []
         self.patch_func = patch_func
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,16 @@
 
 import os
 
+import manager
 import pytest
 
-import manager
+import spack.extensions
 from spack.test.conftest import *  # noqa: F401 F403
 
 _test_root = os.path.dirname(__file__)
+
+spack.extensions.load_extension("manager")
+manager_mod = spack.extensions.get_module("manager")
 
 
 class Patcher(object):
@@ -25,7 +29,6 @@ class Patcher(object):
     """
 
     def __init__(self, patch_func=None):
-        breakpoint()
         self.args = []
         self.patch_func = patch_func
 
@@ -73,13 +76,14 @@ def arg_capture_patch():
 
 
 @pytest.fixture
-def mock_manager_config_path():
+def mock_manager_config_path(monkeypatch):
     """
     Setup to use a testing project repo embedded in the tests, then reset to default when finished
     """
     config_path = os.path.join(_test_root, "mock", "mock_config.yaml")
     manager.config_path = config_path
     manager.initialize()
+    monkeypatch.setattr(manager_mod.find_machine.m_proj, "config_yaml", manager.config_yaml)
     yield
     manager.config_path = manager._default_config_path
     manager.initialize()

--- a/tests/test_create_dev_env.py
+++ b/tests/test_create_dev_env.py
@@ -8,7 +8,7 @@
 import os
 
 import spack.environment as ev
-import spack.extensions.manager.manager_cmds.create_dev_env as create_dev_env
+import manager.manager_cmds.create_dev_env as create_dev_env
 import spack.main
 
 manager = spack.main.SpackCommand("manager")

--- a/tests/test_create_env.py
+++ b/tests/test_create_env.py
@@ -9,6 +9,7 @@ import os
 
 import pytest
 
+import spack.config
 import spack.environment as env
 import spack.main
 import spack.util.spack_yaml as syaml

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -10,8 +10,12 @@ import os
 import pytest
 
 import spack.environment as ev
-import manager.manager_cmds.develop as m_develop
+import spack.extensions
 import spack.main
+
+# monkeypatchable import path for the extension
+spack.extensions.load_extension("manager")
+manager_mod = spack.extensions.get_module("manager")
 
 env = spack.main.SpackCommand("env")
 manager = spack.main.SpackCommand("manager")
@@ -21,7 +25,7 @@ manager = spack.main.SpackCommand("manager")
 def test_spackManagerDevelopCallsSpackDevelop(monkeypatch, arg_capture):
     env("create", "test")
     with ev.read("test"):
-        monkeypatch.setattr(m_develop, "s_develop", arg_capture)
+        monkeypatch.setattr(manager_mod.develop, "s_develop", arg_capture)
         manager("develop", "mpich@=1.0")
         assert arg_capture.num_calls == 1
 
@@ -36,9 +40,9 @@ def test_spackManagerExtensionArgsLeadToGitCalls(
     mock_develop = arg_capture_patch()
     mock_git_clone = arg_capture_patch()
     mock_git_remote = arg_capture_patch()
-    monkeypatch.setattr(m_develop, "s_develop", mock_develop)
-    monkeypatch.setattr(m_develop, "git_clone", mock_git_clone)
-    monkeypatch.setattr(m_develop, "git_remote_add", mock_git_remote)
+    monkeypatch.setattr(manager_mod.develop, "s_develop", mock_develop)
+    monkeypatch.setattr(manager_mod.develop, "git_clone", mock_git_clone)
+    monkeypatch.setattr(manager_mod.develop, "git_remote_add", mock_git_remote)
     env("create", "test")
     with ev.read("test") as e:
         branch = "master"

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -10,8 +10,7 @@ import os
 import pytest
 
 import spack.environment as ev
-import spack.extensions
-import spack.extensions.manager.manager_cmds.develop as m_develop
+import manager.manager_cmds.develop as m_develop
 import spack.main
 
 env = spack.main.SpackCommand("env")

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -7,14 +7,14 @@
 
 import os
 
-import pytest
-
-import spack.environment as ev
 import manager.manager_cmds.external as m_external
-import spack.main
-import spack.util.spack_yaml as syaml
+import pytest
 from manager.manager_cmds.external import external
 from manager.manager_utils import pruned_spec_string
+
+import spack.environment as ev
+import spack.main
+import spack.util.spack_yaml as syaml
 from spack.spec import Spec
 
 env = spack.main.SpackCommand("env")

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -10,11 +10,11 @@ import os
 import pytest
 
 import spack.environment as ev
-import spack.extensions.manager.manager_cmds.external as m_external
+import manager.manager_cmds.external as m_external
 import spack.main
 import spack.util.spack_yaml as syaml
-from spack.extensions.manager.manager_cmds.external import external
-from spack.extensions.manager.manager_utils import pruned_spec_string
+from manager.manager_cmds.external import external
+from manager.manager_utils import pruned_spec_string
 from spack.spec import Spec
 
 env = spack.main.SpackCommand("env")

--- a/tests/test_find_machine.py
+++ b/tests/test_find_machine.py
@@ -8,9 +8,14 @@
 import os
 
 import manager
-import manager.manager_cmds.find_machine as find_machine
+
+import spack.extensions
 import spack.main
 
+# monkeypatchable import path for the extension
+spack.extensions.load_extension("manager")
+manager_mod = spack.extensions.get_module("manager")
+find_machine = manager_mod.find_machine
 mgr_cmd = spack.main.SpackCommand("manager")
 
 

--- a/tests/test_find_machine.py
+++ b/tests/test_find_machine.py
@@ -7,8 +7,8 @@
 
 import os
 
-import spack.extensions.manager as manager
-import spack.extensions.manager.manager_cmds.find_machine as find_machine
+import manager
+import manager.manager_cmds.find_machine as find_machine
 import spack.main
 
 mgr_cmd = spack.main.SpackCommand("manager")

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -8,7 +8,6 @@
 import pytest
 
 import spack.environment as ev
-import spack.extensions
 import spack.main
 
 env = spack.main.SpackCommand("env")

--- a/tests/test_spack_manager_init.py
+++ b/tests/test_spack_manager_init.py
@@ -7,7 +7,7 @@
 
 import os
 
-import spack.extensions.manager as manager
+import manager
 
 
 def test_spackManagerHasConfigPath():


### PR DESCRIPTION
Allow python 3.6 support to match range supported by spack.

I'm still not sure I understand what causes the imports to fail with python@3.6, but the extension works when we use relative imports rather than `spack.extensions`.  To get mocking correct in the unit-test we can use the `spack.extensions.get_module` to get the imports correct.

It's a little convoluted but we can drop this when spack drops support for `python@3.6`.