### PR TITLE
Add buildcache creation to distribution cmd

### DIFF
--- a/manager/manager_cmds/create_env.py
+++ b/manager/manager_cmds/create_env.py
@@ -46,10 +46,7 @@ def create_env(parser, args):
             manifest.add_user_spec(str(s))
 
     if args.local_source:
-        if spack.spack_version_info[0:3] < (0, 23, 0):
-            manifest.set_config_value("config", "install_tree", {"root": "$env/opt"})
-        else:
-            manifest.set_config_value("config", "install_tree", "$env/opt")
+        manifest.set_config_value("config", "install_tree", {"root": "$env/opt"})
 
     # handle includes, if it is not set up right then nothing gets created
     include_dict = {"machine": args.machine, "dir": theDir, "file": "include.yaml"}

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -8,6 +8,7 @@ import spack.extensions
 import spack.llnl.util.tty as tty
 import spack.util.path
 import spack.util.spack_yaml
+import spack.verify
 from spack import environment
 from spack.cmd.mirror import create_mirror_for_all_specs, filter_externals
 from spack.llnl.util.filesystem import working_dir
@@ -47,6 +48,23 @@ def add_command(parser, command_dict):
         help=(
             "Directory where any aditional data to be copied "
             "into the root of the packaged distribution"
+        ),
+    )
+    group = subparser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--source-only",
+        action="store_true",
+        help=(
+            "Only create a source mirror for packages in the environment. "
+            "Default is to create a source and binary mirror"
+        ),
+    )
+    group.add_argument(
+        "--binary-only",
+        action="store_true",
+        help=(
+            "Only create a binary mirror for packages in the environment. "
+            "Default is to create a source and binary mirror"
         ),
     )
     command_dict["distribution"] = distribution
@@ -135,7 +153,8 @@ class DistributionPackager:
         self.path = root
         self.package_repos = os.path.join(self.path, "spack_repo")
         self.extensions = os.path.join(self.path, "extensions")
-        self.mirror = os.path.join(self.path, "mirror")
+        self.source_mirror = os.path.join(self.path, "source-mirror")
+        self.binary_mirror = os.path.join(self.path, "binary-mirror")
         self.bootstrap_mirror = os.path.join(self.path, "bootstrap-mirror")
         self.spack_dir = os.path.join(self.path, "spack")
 
@@ -282,28 +301,44 @@ class DistributionPackager:
         # However, this causes issues for packages that are not downloadable,
         # so we do a first-shot mirror creation with the original environment active.
         with self.environment_to_package:
-            tty.msg(f"Creating mirror at {self.mirror}....")
+            tty.msg(f"Creating source mirror at {self.source_mirror}....")
             create_mirror_for_all_specs(
                 mirror_specs=filter_externals(self.environment_to_package.all_specs()),
-                path=self.mirror,
+                path=self.source_mirror,
                 skip_unstable_versions=False,
             )
 
         with self.env:
-            tty.msg(f"Updating mirror at {self.mirror}....")
+            tty.msg(f"Updating mirror at {self.source_mirror}....")
             create_mirror_for_all_specs(
                 mirror_specs=filter_externals(self.env.all_specs()),
-                path=self.mirror,
+                path=self.source_mirror,
                 skip_unstable_versions=False,
             )
             mirror_path = os.path.join(
-                os.path.relpath(self.path, self.env.path), os.path.basename(self.mirror)
+                os.path.relpath(self.path, self.env.path), os.path.basename(self.source_mirror)
             )
 
             mirrorer = SpackCommand("mirror")
             tty.msg(f"Adding mirror to env: {self.env.name}....")
             with self.env.write_transaction():
-                mirrorer("add", "internal", mirror_path)
+                mirrorer("add", "internal-source", mirror_path)
+
+    def configure_binary_mirror(self):
+        cacher = SpackCommand("buildcache")
+        with self.environment_to_package:
+            tty.msg(f"Creating binary mirror at {self.binary_mirror}....")
+            cacher("push", "--unsigned", self.binary_mirror)
+
+        mirrorer = SpackCommand("mirror")
+        mirror_path = os.path.join(
+            os.path.relpath(self.path, self.env.path), os.path.basename(self.binary_mirror)
+        )
+
+        with self.env:
+            tty.msg(f"Adding mirror to env: {self.env.name}....")
+            with self.env.write_transaction():
+                mirrorer("add", "--type", "binary", "internal-binary", mirror_path)
 
     def configure_bootstrap_mirror(self):
         tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")
@@ -354,8 +389,34 @@ class DistributionPackager:
             spack.util.spack_yaml.dump(data, outf, default_flow_style=False)
 
 
+def correct_mirror_args(env, args):
+    if args.source_only:
+        return
+    if not env.concretized_specs():
+        tty.warn("No installed specs detected, defaulting to source-only package")
+        args.source_only = True
+    for _, concretized in env.concretized_specs():
+        verification = spack.verify.check_spec_manifest(concretized)
+        if verification.has_errors():
+            tty.warn(
+                "The following installation errors were detected, "
+                "defaulting to source-only package"
+            )
+            tty.warn(verification)
+            args.source_only = True
+            break
+    if args.source_only and args.binary_only:
+        tty.error(
+            "Binary distribution requested, but the environment does not "
+            "include the necessary installed binary packages"
+        )
+        raise SystemExit(1)
+
+
 def distribution(parser, args):
     env = spack.cmd.require_active_env(cmd_name="manager distribution")
+    correct_mirror_args(env, args)
+
     packager = DistributionPackager(
         env,
         args.distro_dir,
@@ -363,6 +424,7 @@ def distribution(parser, args):
         excludes=args.exclude,
         extra_data=args.extra_data,
     )
+
     with packager:
         packager.configure_specs()
         packager.configure_includes()
@@ -371,7 +433,10 @@ def distribution(parser, args):
         packager.configure_package_settings(filter_externals=args.filter_externals)
         packager.filter_excludes()
         packager.concretize()
-        packager.configure_source_mirror()
+        if not args.binary_only:
+            packager.configure_source_mirror()
+        if not args.source_only:
+            packager.configure_binary_mirror()
         packager.configure_bootstrap_mirror()
         packager.bundle_spack()
         packager.bundle_extra_data()

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -3,7 +3,6 @@ import os
 import shutil
 
 import spack.cmd
-import spack.cmd.mirror
 import spack.config
 import spack.environment
 import spack.extensions
@@ -13,6 +12,7 @@ import spack.llnl.util.filesystem as fs
 import spack.util.path
 import spack.util.spack_yaml
 import spack.spec
+from spack.cmd.mirror import create_mirror_for_all_specs, filter_externals
 from spack.main import SpackCommand
 from spack.paths import spack_root
 
@@ -304,8 +304,8 @@ class DistributionPackager:
         # so we do a first-shot mirror creation with the original environment active.
         with self.environment_to_package:
             tty.msg(f"Creating source mirror at {self.source_mirror}....")
-            spack.cmd.mirror.create_mirror_for_all_specs(
-                mirror_specs=spack.cmd.mirror.filter_externals(
+            create_mirror_for_all_specs(
+                mirror_specs=filter_externals(
                     self.environment_to_package.all_specs()
                 ),
                 path=self.source_mirror,
@@ -314,8 +314,8 @@ class DistributionPackager:
 
         with self.env:
             tty.msg(f"Updating mirror at {self.source_mirror}....")
-            spack.cmd.mirror.create_mirror_for_all_specs(
-                mirror_specs=spack.cmd.mirror.filter_externals(self.env.all_specs()),
+            create_mirror_for_all_specs(
+                mirror_specs=filter_externals(self.env.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
             )

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -8,7 +8,6 @@ import spack.environment
 import spack.extensions
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
-import spack.llnl.util.filesystem as fs
 import spack.util.path
 import spack.util.spack_yaml
 import spack.spec

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -8,9 +8,9 @@ import spack.environment
 import spack.extensions
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
+import spack.spec
 import spack.util.path
 import spack.util.spack_yaml
-import spack.spec
 from spack.cmd.mirror import create_mirror_for_all_specs, filter_externals
 from spack.main import SpackCommand
 from spack.paths import spack_root
@@ -304,9 +304,7 @@ class DistributionPackager:
         with self.environment_to_package:
             tty.msg(f"Creating source mirror at {self.source_mirror}....")
             create_mirror_for_all_specs(
-                mirror_specs=filter_externals(
-                    self.environment_to_package.all_specs()
-                ),
+                mirror_specs=filter_externals(self.environment_to_package.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
             )
@@ -327,7 +325,7 @@ class DistributionPackager:
             with self.env.write_transaction():
                 mirrorer("add", "internal-source", mirror_path)
 
-    def configure_binary_mirror(self): 
+    def configure_binary_mirror(self):
         cacher = SpackCommand("buildcache")
         with self.environment_to_package:
             tty.msg(f"Creating binary mirror at {self.binary_mirror}....")
@@ -340,7 +338,7 @@ class DistributionPackager:
         )
         mirror_name = "internal-binary"
 
-        with self.env:  
+        with self.env:
             tty.msg(f"Adding mirror to env: {self.env.name}....")
             with self.env.write_transaction():
                 mirrorer("add", "--type", "binary", "--unsigned", mirror_name, mirror_path)

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -7,6 +7,7 @@ import spack.cmd.mirror
 import spack.config
 import spack.environment
 import spack.extensions
+import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.llnl.util.filesystem as fs
 import spack.util.path
@@ -304,7 +305,9 @@ class DistributionPackager:
         with self.environment_to_package:
             tty.msg(f"Creating source mirror at {self.source_mirror}....")
             spack.cmd.mirror.create_mirror_for_all_specs(
-                mirror_specs=spack.cmd.mirror.filter_externals(self.environment_to_package.all_specs()),
+                mirror_specs=spack.cmd.mirror.filter_externals(
+                    self.environment_to_package.all_specs()
+                ),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
             )
@@ -342,7 +345,6 @@ class DistributionPackager:
             tty.msg(f"Adding mirror to env: {self.env.name}....")
             with self.env.write_transaction():
                 mirrorer("add", "--type", "binary", "--unsigned", mirror_name, mirror_path)
-
 
     def configure_bootstrap_mirror(self):
         tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -406,11 +406,10 @@ def correct_mirror_args(env, args):
             args.source_only = True
             break
     if args.source_only and args.binary_only:
-        tty.error(
+        tty.die(
             "Binary distribution requested, but the environment does not "
             "include the necessary installed binary packages"
         )
-        raise SystemExit(1)
 
 
 def distribution(parser, args):

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -397,15 +397,16 @@ class DistributionPackager:
 
 def is_installed(spec):
     status = True
-    for dependency in spec.dependencies(deptype="run"):
+    for dependency in spec.dependencies(deptype=("link", "run")):
         status = is_installed(dependency)
     bad_statuses = [spack.spec.InstallStatus.absent, spack.spec.InstallStatus.missing]
     return status and spec.install_status() not in bad_statuses
 
 
 def correct_mirror_args(env, args):
-    specs_to_check = env.concretized_specs()
-    has_installed_specs = all([len(specs_to_check)] + [is_installed(x) for _, x in specs_to_check])
+    specs_to_check = list(env.concretized_specs())
+    install_status = [len(specs_to_check)] + [is_installed(x) for _, x in specs_to_check]
+    has_installed_specs = all(install_status)
     if not args.source_only and not has_installed_specs:
         tty.warn("Environment contains uninstalled specs, defaulting to source-only package")
         if args.binary_only:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -57,7 +57,7 @@ def {base_name}(parser, args):
 
 def create_repo(path):
     os.makedirs(path)
-    data = {"repo": {"namespace": "test"}}
+    data = {"repo": {"namespace": os.path.basename(path)}}
     with open(os.path.join(path, "repo.yaml"), "w") as f:
         spack.util.spack_yaml.dump(data, f, default_flow_style=False)
     package = os.path.join(path, "packages", "test")
@@ -507,7 +507,6 @@ def test_DistributionPackager_configure_extensions(tmpdir):
     with tmpdir.as_cwd():
         pkgr.configure_extensions()
     mod_content = get_manifest(pkgr.env)
-    print("content", mod_content)
 
     for extension in expected_extensions:
         assert os.path.isdir(os.path.join(pkgr.env.path, extension))
@@ -521,10 +520,17 @@ def test_DistributionPackager_configure_repos(tmpdir):
     the environment into the environment being created and adds a relative path to the
     copied repositories to the spack.yaml that is being constructed.
     """
-    package_repo = os.path.join(tmpdir.strpath, "mock-repo")
+    package_repo = os.path.join(tmpdir.strpath, "mock_repo")
     create_repo(package_repo)
 
-    extra_data = {"repos": {"mock-repo": package_repo}}
+    package_repo2 = os.path.join(tmpdir.strpath, "mock_repo2")
+    create_repo(package_repo2)
+
+    data = spack.util.spack_yaml.syaml_dict()
+    data["mock_repo"] = package_repo
+    data["mock_repo2"] = package_repo2
+
+    extra_data = {"repos": data}
     manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
     create_spack_manifest(manifest, extra_data=extra_data)
     env = spack.environment.Environment(os.path.dirname(manifest))
@@ -541,8 +547,11 @@ def test_DistributionPackager_configure_repos(tmpdir):
     assert os.path.isdir(expected_repo_dir)
     assert "repos" in result_config["spack"]
 
-    expected_repo = {"mock-repo": f"../{os.path.basename(pkgr.package_repos)}/mock-repo"}
-    assert expected_repo == result_config["spack"]["repos"]
+    expected = spack.util.spack_yaml.syaml_dict()
+    for key, val in data.items():
+        expected[key] = f"../{os.path.basename(pkgr.package_repos)}/{os.path.basename(val)}"
+
+    assert expected == result_config["spack"]["repos"]
 
 
 def test_DistributionPackager_configure_package_settings(tmpdir):
@@ -554,7 +563,7 @@ def test_DistributionPackager_configure_package_settings(tmpdir):
     when `filter_externals` is `True`.
     """
     good = {"all": {"prefer": ["generator=Ninja"]}}
-    bad = {"cmake": {"externals": [{"spec": "cmake@1.2.3", "path": "/foo/bar"}]}}
+    bad = {"cmake": {"externals": [{"spec": "cmake@1.2.3", "prefix": "/foo/bar"}]}}
 
     extra_data = {"packages": {}}
     extra_data["packages"].update(good)


### PR DESCRIPTION
Adds ability to bundle a buildcache with a spack distribution. The command will default to creating both a binary and source mirror. Currently signing of binaries when pushing them to the cache will be disabled.