### PR TITLE
Fix repository order bug in distribution command

### DIFF
--- a/manager/manager_cmds/create_env.py
+++ b/manager/manager_cmds/create_env.py
@@ -46,10 +46,7 @@ def create_env(parser, args):
             manifest.add_user_spec(str(s))
 
     if args.local_source:
-        if spack.spack_version_info[0:3] < (0, 23, 0):
-            manifest.set_config_value("config", "install_tree", {"root": "$env/opt"})
-        else:
-            manifest.set_config_value("config", "install_tree", "$env/opt")
+        manifest.set_config_value("config", "install_tree", {"root": "$env/opt"})
 
     # handle includes, if it is not set up right then nothing gets created
     include_dict = {"machine": args.machine, "dir": theDir, "file": "include.yaml"}

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -8,7 +8,6 @@
 import inspect
 import os
 from argparse import ArgumentParser
-from collections import OrderedDict
 
 import spack
 import spack.cmd.bootstrap as test_bootstrap_parse

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -403,7 +403,6 @@ def test_DistributionPackager_configure_extensions(tmpdir):
     with tmpdir.as_cwd():
         pkgr.configure_extensions()
     mod_content = get_manifest(pkgr.env)
-    print("content", mod_content)
 
     for extension in expected_extensions:
         assert os.path.isdir(os.path.join(pkgr.env.path, extension))
@@ -423,7 +422,7 @@ def test_DistributionPackager_configure_repos(tmpdir):
     package_repo2 = os.path.join(tmpdir.strpath, "mock_repo2")
     create_repo(package_repo2)
 
-    data = OrderedDict()
+    data = spack.util.spack_yaml.syaml_dict()
     data["mock_repo"] = package_repo
     data["mock_repo2"] = package_repo2
 
@@ -444,7 +443,7 @@ def test_DistributionPackager_configure_repos(tmpdir):
     assert os.path.isdir(expected_repo_dir)
     assert "repos" in result_config["spack"]
 
-    expected = OrderedDict()
+    expected = spack.util.spack_yaml.syaml_dict()
     for key, val in data.items():
         expected[key] = f"../{os.path.basename(pkgr.package_repos)}/{os.path.basename(val)}"
 
@@ -460,7 +459,7 @@ def test_DistributionPackager_configure_package_settings(tmpdir):
     when `filter_externals` is `True`.
     """
     good = {"all": {"prefer": ["generator=Ninja"]}}
-    bad = {"cmake": {"externals": [{"spec": "cmake@1.2.3", "path": "/foo/bar"}]}}
+    bad = {"cmake": {"externals": [{"spec": "cmake@1.2.3", "prefix": "/foo/bar"}]}}
 
     extra_data = {"packages": {}}
     extra_data["packages"].update(good)


### PR DESCRIPTION
The distribution command was modifying the list of repos in a given spack environment which causes problems when resolving package dependencies. Maintain the original package repository data structure throughout the distro bundling process so that this does not occur.