### PR TITLE
Distribution extra spack cleanup

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -393,11 +393,10 @@ class DistributionPackager:
 
 
 def is_installed(spec):
-    status = True
-    for dependency in spec.dependencies(deptype=("link", "run")):
-        status = is_installed(dependency)
+    deps = list(spec.dependencies(deptype=("link", "run")))
     bad_statuses = [spack.spec.InstallStatus.absent, spack.spec.InstallStatus.missing]
-    return status and spec.install_status() not in bad_statuses
+    dep_status = [x.install_status() not in bad_statuses for x in deps]
+    return all(dep_status) and spec.install_status() not in bad_statuses
 
 
 def correct_mirror_args(env, args):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -715,7 +715,7 @@ def test_DistributionPackager_configure_source_mirror_create_mirror_called_corre
 
     def mirror_for_specs(*args, **kwargs):
         assert len(args) == 0
-        assert len(kwargs) == len(valid_params)
+        assert len(kwargs) <= len(valid_params)
         for kwarg in kwargs:
             assert kwarg in valid_params
 


### PR DESCRIPTION
The distribution command was including files specific to the user's spack environment
were getting bundled along with spack.  This is because spack writes into its root
directory as it is being used.  This creates a more exhaustive list of locations
to avoid copying along with spack and more aggressively asserts they don't end up in
the final spack installation