### PR TITLE
Add workers argument to create_mirror_for_all_specs function in distribution script

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -312,6 +312,7 @@ class DistributionPackager:
                 mirror_specs=filter_externals(self.environment_to_package.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
+                workers=spack.config.determine_number_of_jobs(parallel=True),
             )
 
         with self.env:
@@ -320,6 +321,7 @@ class DistributionPackager:
                 mirror_specs=filter_externals(self.env.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
+                workers=spack.config.determine_number_of_jobs(parallel=True),
             )
             mirror_path = os.path.join(
                 os.path.relpath(self.path, self.env.path), os.path.basename(self.source_mirror)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -96,7 +96,7 @@ def setupExternalEnv(tmpdir, has_view=True):
     return env_path
 
 
-def test_failsWithNoProject(tmpdir, capsys):
+def test_failsWithNoProject(tmpdir):
     yaml_file = """spack:
   view: true
   specs: [mpileaks]"""
@@ -110,7 +110,6 @@ def test_failsWithNoProject(tmpdir, capsys):
         with pytest.raises(SystemExit):
             with ev.Environment("test"):
                 external(None, args)
-                assert "No project detected." in capsys.readouterr()
 
 
 def test_errorsIfThereIsNoView(tmpdir, on_moonlight):


### PR DESCRIPTION
A change in the develop branch of Spack has caused an error with our distribution.py script. The function `create_mirror_for_all_specs` now has a required argument "workers" that was previously not set. 

This PR adds the workers argument to be set to the job number defined by Spack by using the `determine_number_of_jobs` function in Spack config.