### PR TITLE
Extract and use full flattened configuration for the initial creation of the distribution environment

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -44,7 +44,6 @@ def add_command(parser, command_dict):
         "--exclude-file",
         help="Sections in the enviroment's configuration file to exclude located a file",
     )
-    create
     subparser.add_argument(
         "--exclude-configs",
         nargs="+",

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -37,8 +37,11 @@ def add_command(parser, command_dict):
     )
     subparser.add_argument(
         "--exclude-configs",
-        nargs="+",
-        help="Sections in the enviroment's configuration file to exclude in a string",
+        type=parse_comma_separated,
+        help=(
+            "Sections in the environment's configuration file to exclude \
+            (comma-separated string without spaces)"
+        ),
     )
     subparser.add_argument(
         "--exclude-file",
@@ -77,6 +80,10 @@ def add_command(parser, command_dict):
         ),
     )
     command_dict["distribution"] = distribution
+
+
+def parse_comma_separated(value):
+    return [item.strip() for item in value.split(",")]
 
 
 def _read_config(filename):
@@ -143,7 +150,7 @@ class DistributionPackager:
         if exclude_file:
             self.exclude_configs.extend(read_yaml_file(exclude_file)["excludes"])
         if exclude_configs:
-            self.exclude_configs.extend((exclude_configs).split())
+            self.exclude_configs.extend(exclude_configs)
         self.extra_data = extra_data
 
         self.path = root

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -227,7 +227,8 @@ class DistributionPackager:
                     flattened_config[section] = spack.config.CONFIG.get(section)
                 except spack.config.ConfigSectionError as e:
                     tty.error(
-                        f"The configuration section: {section} does not exist in {self.environment_to_package.name}. The error returned is: {e}"
+                        f"The configuration section: {section} does not exist in \
+                            {self.environment_to_package.name}. The error returned is: {e}"
                     )
         return flattened_config
 
@@ -241,7 +242,8 @@ class DistributionPackager:
                         )
                     except spack.config.ConfigFormatError as e:
                         tty.error(
-                            f"The configuration section: {section} has incorrect syntax in the environment. The error returned is: {e}"
+                            f"The configuration section: {section} has incorrect syntax \
+                                in the environment. The error returned is: {e}"
                         )
 
     def filter_exclude_configs(self):

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -45,11 +45,6 @@ def add_command(parser, command_dict):
         help="Sections in the enviroment's configuration file to exclude located a file",
     )
     subparser.add_argument(
-        "--exclude-configs",
-        nargs="+",
-        help="Sections in the enviroment's configuration file to exclude",
-    )
-    subparser.add_argument(
         "--filter-externals",
         action="store_true",
         help=(

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -312,6 +312,7 @@ class DistributionPackager:
                 mirror_specs=filter_externals(self.environment_to_package.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
+                workers=spack.config.determine_number_of_jobs(parallel=True),
             )
 
         with self.env:
@@ -320,6 +321,7 @@ class DistributionPackager:
                 mirror_specs=filter_externals(self.env.all_specs()),
                 path=self.source_mirror,
                 skip_unstable_versions=False,
+                workers=spack.config.determine_number_of_jobs(parallel=True),
             )
             mirror_path = os.path.join(
                 os.path.relpath(self.path, self.env.path), os.path.basename(self.source_mirror)

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -138,7 +138,7 @@ class DistributionPackager:
 
         self._env = None
         self._cached_env = None
-        self._flattened_config  = {}
+        self._flattened_config = {}
 
     def __enter__(self):
         self._cached_env = spack.environment.active_environment()
@@ -186,18 +186,18 @@ class DistributionPackager:
                 os.remove(fullname)
 
     def get_flattened_config(self):
-        with self.environment_to_package:            
+        with self.environment_to_package:
             for section in spack.config.SECTION_SCHEMAS:
                 if section in SKIP_CONFIG_SECTION:
                     continue
                 self._flattened_config[section] = spack.config.CONFIG.get(section)
-        # Set up correct relative path for Spack extensions
+            # Set up correct relative path for Spack extensions
             extensions = spack.extensions.get_extension_paths()
             new_extensions = []
             for extension in extensions:
                 extension = os.path.join(
-                        os.path.relpath(self.extensions, self.env.path), os.path.basename(extension)
-                    )
+                    os.path.relpath(self.extensions, self.env.path), os.path.basename(extension)
+                )
                 new_extensions.append(extension)
             self._flattened_config["config"]["extensions"] = new_extensions
 
@@ -205,7 +205,9 @@ class DistributionPackager:
         with self.env:
             for section in self._flattened_config:
                 if self._flattened_config[section]:
-                    spack.config.CONFIG.set(section, self._flattened_config[section], scope=self.env.scope_name)
+                    spack.config.CONFIG.set(
+                        section, self._flattened_config[section], scope=self.env.scope_name
+                    )
 
     def filter_exclude_configs(self):
         if self.exclude_configs:

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -22,7 +22,7 @@ level = "long"
 
 
 SPACK_USER_PATTERNS = ["var/*", "opt/*", ".git*", "etc/spack/*"]
-SKIP_CONFIG_SECTION = ["mirrors", "repos", "include"]
+SKIP_CONFIG_SECTION = ["mirrors", "repos", "include", "packages"]
 
 
 def add_command(parser, command_dict):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -431,7 +431,7 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_fi
     extra_data = {"packages": {"gcc": {"require": ["@1.2.3"]}}}
     extra_data_2 = {"env_vars": {"set": {"TEST_ENV_VARS": "123456"}}}
     combined_data = extra_data.copy()
-    combined_data.update(extra_data_2) 
+    combined_data.update(extra_data_2)
     create_spack_manifest(manifest, extra_data=combined_data)
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
@@ -460,7 +460,7 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config(tmpdir
     extra_data = {"packages": {"gcc": {"require": ["@1.2.3"]}}}
     extra_data_2 = {"env_vars": {"set": {"TEST_ENV_VARS": "123456"}}}
     combined_data = extra_data.copy()
-    combined_data.update(extra_data_2) 
+    combined_data.update(extra_data_2)
     create_spack_manifest(manifest, extra_data=combined_data)
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
@@ -574,7 +574,7 @@ def test_DistributionPackager_configure_specs(tmpdir):
 
 def test_DistributionPackager_copy_extensions_files(tmpdir, monkeypatch):
     """
-    This test verifies that `copy_extensions_files` creates file assocated 
+    This test verifies that `copy_extensions_files` creates file assocated
     with the correct extensions path
     """
     root = os.path.join(tmpdir.strpath, "root")

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -971,17 +971,14 @@ def test_DistributionPackager_init_config(tmpdir, monkeypatch):
         "concretizer": {},
         "config": {"extensions": {"test"}},
     }
-    flattened_config["config"]["extensions"] = distribution.get_relative_paths(
+    new_path = distribution.get_relative_paths(
         extensions_path, pkgr.path, os.path.join(root, "extensions")
     )
     pkgr._create_config_file(flattened_config)
     with pkgr.env:
         for section in flattened_config:
             if section == "config":
-                assert (
-                    flattened_config[section]["extensions"]
-                    != spack.config.CONFIG.get(section)["extensions"]
-                )
+                assert new_path != flattened_config[section]["extensions"]
             elif section == "concretizer":
                 assert flattened_config[section] != spack.config.CONFIG.get(section)
             else:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -459,7 +459,9 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config(tmpdir
     manifest = os.path.join(root, "environment", "spack.yaml")
     extra_data = {"packages": {"gcc": {"require": ["@1.2.3"]}}}
     extra_data_2 = {"env_vars": {"set": {"TEST_ENV_VARS": "123456"}}}
-    create_spack_manifest(manifest, extra_data=(extra_data | extra_data_2))
+    combined_data = extra_data.copy()
+    combined_data.update(extra_data_2) 
+    create_spack_manifest(manifest, extra_data=combined_data)
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -939,14 +939,14 @@ def test_DistributionPackager_get_flattened_config(tmpdir, monkeypatch):
     monkeypatch.setattr(spack.config, "SECTION_SCHEMAS", TEST_SECTION_SCHEMAS)
     pkgr.get_flattened_config()
     assert "compilers" in pkgr._flattened_config
-    assert "packages" in pkgr._flattened_config
+    assert "definitions" in pkgr._flattened_config
     assert "toolchains" in pkgr._flattened_config
     assert (
         TEST_SECTION_SCHEMAS["config"]["extensions"]
         != pkgr._flattened_config["config"]["extensions"]
     )
-    assert "mirrors" not in pkgr._flattened_config
-    assert "include" not in pkgr._flattened_config
+    for section in pkgr.SKIP_CONFIG_SECTION:
+        assert section not in pkgr._flattened_config
 
 
 def test_get_relative_paths():

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -21,7 +21,6 @@ import spack.environment
 import spack.extensions
 import spack.spec
 import spack.util.spack_yaml
-from spack.main import SpackCommand
 
 
 def create_spack_manifest(path, specs=None, extra_data=None):
@@ -47,11 +46,11 @@ def create_package_manifest(path):
 
 
 def create_extension(extension_name):
-    content = f"""\
+    content = """\
 def test(parser, args):
     return None
 """
-    extension_file = os.path.join(extension_name, f"test.py")
+    extension_file = os.path.join(extension_name, "test.py")
     os.makedirs(os.path.dirname(extension_file))
     with open(extension_file, "w") as f:
         f.write(content)
@@ -571,7 +570,8 @@ def test_DistributionPackager_configure_specs(tmpdir):
 
 def test_DistributionPackager_copy_extensions_files(tmpdir, monkeypatch):
     """
-    This test verifies that `copy_extensions_files` creates file assocated with the correct extensions path
+    This test verifies that `copy_extensions_files` creates file assocated 
+    with the correct extensions path
     """
     root = os.path.join(tmpdir.strpath, "root")
     manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
@@ -959,7 +959,6 @@ def test_get_relative_paths():
 def test_DistributionPackager_create_config(tmpdir, monkeypatch):
     manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
     create_spack_manifest(manifest)
-    env_dir = os.path.dirname(manifest)
     env = spack.environment.Environment(os.path.dirname(manifest))
     root = os.path.join(tmpdir.strpath, "root")
     pkgr = distribution.DistributionPackager(env, root)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -430,7 +430,9 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_fi
     manifest = os.path.join(root, "environment", "spack.yaml")
     extra_data = {"packages": {"gcc": {"require": ["@1.2.3"]}}}
     extra_data_2 = {"env_vars": {"set": {"TEST_ENV_VARS": "123456"}}}
-    create_spack_manifest(manifest, extra_data=(extra_data | extra_data_2))
+    combined_data = extra_data.copy()
+    combined_data.update(extra_data_2) 
+    create_spack_manifest(manifest, extra_data=combined_data)
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -430,21 +430,26 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_fi
     manifest = os.path.join(root, "environment", "spack.yaml")
     extra_data = {"packages": {"gcc": {"require": ["@1.2.3"]}}}
     extra_data_2 = {"env_vars": {"set": {"TEST_ENV_VARS": "123456"}}}
+    extra_data_3 = {"env_vars": {"set": {"TEST_ENV_VARS_2": "123456"}}}
     combined_data = extra_data.copy()
     combined_data.update(extra_data_2)
+    combined_data.update(extra_data_3)
     create_spack_manifest(manifest, extra_data=combined_data)
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
 
     pkgr = distribution.DistributionPackager(
-        None, root, exclude_configs="env_vars:set:TEST_ENV_VARS", exclude_file=exclude_file
+        None,
+        root,
+        exclude_configs=["env_vars:set:TEST_ENV_VARS", "env_vars:set:TEST_ENV_VARS_2"],
+        exclude_file=exclude_file,
     )
     pkgr._env = env
     pkgr.filter_exclude_configs()
 
     content = get_manifest(pkgr.env)
     assert extra_data["packages"] != content["spack"]["packages"]
-    assert extra_data_2["env_vars"] != content["spack"]["env_vars"]
+    assert combined_data["env_vars"]["set"] != content["spack"]["env_vars"]["set"]
     assert "packages" in content["spack"]
     assert "env_vars" in content["spack"]
     assert "specs" in content["spack"]
@@ -466,7 +471,7 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config(tmpdir
     env = get_fake_concretize_env(env_dir)
 
     pkgr = distribution.DistributionPackager(
-        None, root, exclude_configs="env_vars:set:TEST_ENV_VARS"
+        None, root, exclude_configs=["env_vars:set:TEST_ENV_VARS"]
     )
     pkgr._env = env
     pkgr.filter_exclude_configs()

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -410,7 +410,8 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_file(tmpdir):
     pkgr.filter_exclude_configs()
 
     content = get_manifest(pkgr.env)
-    assert extra_data["packages"] != content["spack"]["packages"]
+    with pytest.raises(KeyError):
+        assert not content["spack"]["packages"]["gcc"]
     assert "packages" in content["spack"]
     assert "specs" in content["spack"]
 
@@ -448,8 +449,12 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_fi
     pkgr.filter_exclude_configs()
 
     content = get_manifest(pkgr.env)
-    assert extra_data["packages"] != content["spack"]["packages"]
-    assert combined_data["env_vars"]["set"] != content["spack"]["env_vars"]["set"]
+    with pytest.raises(KeyError):
+        assert not content["spack"]["packages"]["gcc"]
+    with pytest.raises(KeyError):
+        assert not content["spack"]["env_vars"]["set"]["TEST_ENV_VARS"]
+    with pytest.raises(KeyError):
+        assert not content["spack"]["env_vars"]["set"]["TEST_ENV_VARS_2"]
     assert "packages" in content["spack"]
     assert "env_vars" in content["spack"]
     assert "specs" in content["spack"]
@@ -478,7 +483,8 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config(tmpdir
 
     content = get_manifest(pkgr.env)
     assert extra_data["packages"] == content["spack"]["packages"]
-    assert extra_data_2["env_vars"] != content["spack"]["env_vars"]
+    with pytest.raises(KeyError):
+        assert not content["spack"]["env_vars"]["set"]["TEST_ENV_VARS"]
     assert "packages" in content["spack"]
     assert "specs" in content["spack"]
 
@@ -945,7 +951,7 @@ def test_DistributionPackager_get_flattened_config(tmpdir, monkeypatch):
         TEST_SECTION_SCHEMAS["config"]["extensions"]
         != pkgr._flattened_config["config"]["extensions"]
     )
-    for section in pkgr.SKIP_CONFIG_SECTION:
+    for section in distribution.SKIP_CONFIG_SECTION:
         assert section not in pkgr._flattened_config
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -96,7 +96,7 @@ def setupExternalEnv(tmpdir, has_view=True):
     return env_path
 
 
-def test_failsWithNoProject(tmpdir, capsys):
+def test_failsWithNoProject(tmpdir):
     yaml_file = """spack:
   view: true
   specs: [mpileaks]"""
@@ -110,7 +110,6 @@ def test_failsWithNoProject(tmpdir, capsys):
         with pytest.raises(SystemExit):
             with ev.Environment("test"):
                 external(None, args)
-                assert "No project detected." in capsys.readouterr()
 
 
 def test_errorsIfThereIsNoView(tmpdir, on_moonlight):


### PR DESCRIPTION
With this change the distribution process will use the fully flattened configuration from the targeted Spack environment. This change was necessary to make sure that we included all of the configuration file that is included in the Spack environment.

Some sections in the configuration have been excluded by default (include, mirrors, repos) and an exclude argument (option to use a file or a command line argument) was added for further customization.