### PR TITLE
Fix bug with distribution not including all necessary assets

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -25,8 +25,9 @@ section = "manager"
 level = "long"
 
 
-SPACK_USER_PATTERNS = ["var/*", "opt/*", ".git*", "etc/spack/*"]
-SKIP_CONFIG_SECTION = ["mirrors", "repos", "include", "packages", "ci", "cdash", "bootstrap"]
+SPACK_USER_EXCLUDE_PATTERNS = ["var/*", "opt/*", ".git*", "etc/spack/*"]
+SPACK_USER_INCLUDE_PATTERNS = ["etc/spack/defaults*"]
+SKIP_CONFIG_SECTION = ["mirrors", "repos", "include", "ci", "cdash", "bootstrap"]
 
 
 def add_command(parser, command_dict):
@@ -114,20 +115,26 @@ def read_yaml_file(filename):
     return data
 
 
-def copy_files_excluding_pattern(src, dst, patterns):
+def copy_files_excluding_pattern(src, dst, exclude_patterns, include_patterns=None):
+    if include_patterns is None:
+        include_patterns = []
     os.makedirs(dst, exist_ok=True)
 
     for dirpath, _, filenames in os.walk(src):
         relative_path = os.path.relpath(dirpath, src)
         dst_dir = os.path.join(dst, relative_path)
-        if not is_match(relative_path, patterns):
+        if not is_match(relative_path, exclude_patterns) or is_match(
+            relative_path, include_patterns
+        ):
             os.makedirs(dst_dir, exist_ok=True)
 
             for filename in filenames:
                 src_file = os.path.join(dirpath, filename)
                 dst_file = os.path.join(dst_dir, filename)
 
-                if not is_match(os.path.join(relative_path, filename), patterns):
+                if not is_match(
+                    os.path.join(relative_path, filename), exclude_patterns
+                ) or is_match(relative_path, include_patterns):
                     shutil.copy2(src_file, dst_file, follow_symlinks=False)
 
 
@@ -138,7 +145,9 @@ def valid_env_scopes(env):
 
 def bundle_spack(location):
     tty.msg(f"Packing up Spack installation to {location}....")
-    copy_files_excluding_pattern(spack_root, location, SPACK_USER_PATTERNS)
+    copy_files_excluding_pattern(
+        spack_root, location, SPACK_USER_EXCLUDE_PATTERNS, SPACK_USER_INCLUDE_PATTERNS
+    )
 
 
 def get_relative_paths(original_paths, env_path, dir_name):
@@ -217,8 +226,12 @@ class DistributionPackager:
         self.env.write()
 
     def remove_unwanted_artifacts(self):
-        for pattern in SPACK_USER_PATTERNS:
-            remove_by_pattern(os.path.join(self.spack_dir, pattern))
+        include_patterns = [
+            os.path.join(self.spack_dir, ipattern) for ipattern in SPACK_USER_INCLUDE_PATTERNS
+        ]
+        for epattern in SPACK_USER_EXCLUDE_PATTERNS:
+            for ipattern in SPACK_USER_INCLUDE_PATTERNS:
+                remove_by_pattern(os.path.join(self.spack_dir, epattern), include_patterns)
         for item in os.listdir(self.env.path):
             fullname = os.path.join(self.env.path, item)
             if "spack.yaml" in item:
@@ -249,6 +262,7 @@ class DistributionPackager:
                         f"The configuration section: {section} does not exist in \
                             {self.environment_to_package.name}. The error returned is: {e}"
                     )
+
         return flattened_config
 
     def _create_config_file(self, flattened_config):
@@ -265,13 +279,21 @@ class DistributionPackager:
                                 in the environment. The error returned is: {e}"
                         )
 
-    def filter_exclude_configs(self):
+    def filter_exclude_configs(self, filter_externals=False):
         if self.exclude_configs:
             with self.env:
                 tty.msg(f"Excluding configurations: {self.exclude_configs}....")
                 for exclude in self.exclude_configs:
                     with self.env.write_transaction():
                         call(spack.cmd.config, "config", ["remove", exclude])
+        if filter_externals:
+            tty.msg("Excluding external packages....")
+            with self.env:
+                packages = spack.config.CONFIG.get("packages")
+                for package in packages:
+                    if "externals" in packages[package]:
+                        with self.env.write_transaction():
+                            call(spack.cmd.config, "config", ["remove", f"packages:{package}"])
 
     def configure_includes(self):
         if self.includes:
@@ -326,22 +348,6 @@ class DistributionPackager:
         env["spack"]["repos"] = repos
         self._write(env)
 
-    def configure_package_settings(self, filter_externals=False):
-        tty.msg(f"Add package settings to env: {self.env.name}....")
-        with self.environment_to_package:
-            package_settings = {}
-            for scope in valid_env_scopes(self.environment_to_package):
-                for package, data in spack.config.get("packages", scope=scope).items():
-                    if "externals" not in data or not filter_externals:
-                        try:
-                            package_settings[package].update(data)
-                        except KeyError:
-                            package_settings[package] = data
-
-        env_data = get_env_as_dict(self.env)
-        env_data["spack"]["packages"] = package_settings
-        self._write(env_data)
-
     def configure_source_mirror(self, filter_specs=None):
         # We do not want to omit any packages that are externals
         # just So They Build Faster internally, but are still needed externally.
@@ -355,25 +361,13 @@ class DistributionPackager:
         with self.environment_to_package:
             tty.msg(f"Creating source mirror at {self.source_mirror}....")
             specs = [x.name for x in self.environment_to_package.all_specs()]
-            args = [
-                "create",
-                "--directory",
-                self.source_mirror,
-                *filter_specs,
-                *specs,
-            ]
+            args = ["create", "--directory", self.source_mirror, *filter_specs, *specs]
             call(spack.cmd.mirror, "mirror", args)
 
         with self.env:
             tty.msg(f"Updating mirror at {self.source_mirror}....")
             specs = [x.name for x in self.env.all_specs()]
-            args = [
-                "create",
-                "--directory",
-                self.source_mirror,
-                *filter_specs,
-                *specs,
-            ]
+            args = ["create", "--directory", self.source_mirror, *filter_specs, *specs]
             call(spack.cmd.mirror, "mirror", args)
 
             mirror_path = os.path.join(
@@ -488,13 +482,18 @@ def correct_mirror_args(env, args):
         args.source_only = True
 
 
-def remove_by_pattern(pattern):
-    for item in glob.glob(pattern, recursive=True):
-        tty.msg(item)
-        if os.path.isfile(item):
-            os.remove(item)
-        elif os.path.isdir(item):
-            shutil.rmtree(item)
+def remove_by_pattern(exclude_pattern, include_patterns):
+    keep_these = []
+    for ipattern in include_patterns:
+        keep_these += list(glob.glob(ipattern, recursive=True))
+
+    for item in glob.glob(exclude_pattern, recursive=True):
+        if item not in keep_these:
+            tty.msg(item)
+            if os.path.isfile(item):
+                os.remove(item)
+            elif os.path.isdir(item):
+                shutil.rmtree(item)
 
 
 def distribution(parser, args):
@@ -512,12 +511,11 @@ def distribution(parser, args):
 
     with packager:
         packager.init_config()
-        packager.filter_exclude_configs()
+        packager.filter_exclude_configs(filter_externals=args.filter_externals)
         packager.configure_includes()
         packager.configure_specs()
         packager.copy_extensions_files()
         packager.configure_package_repos()
-        packager.configure_package_settings(filter_externals=args.filter_externals)
         packager.configure_bootstrap_mirror()
         packager.concretize()
         if not args.binary_only:

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -117,8 +117,8 @@ def read_yaml_file(filename):
 
 def copy_files_excluding_pattern(src, dst, exclude_patterns, include_patterns=None):
     """
-    Include_patterns are used to override subsets of the exclude_patterns (include_patterns are always
-    copied no matter what is defined in the exclude_patterns)
+    Include_patterns are used to override subsets of the exclude_patterns (include_patterns are
+    always copied no matter what is defined in the exclude_patterns)
     """
     if include_patterns is None:
         include_patterns = []

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -116,6 +116,10 @@ def read_yaml_file(filename):
 
 
 def copy_files_excluding_pattern(src, dst, exclude_patterns, include_patterns=None):
+    """
+    Include_patterns are used to override subsets of the exclude_patterns (include_patterns are always
+    copied no matter what is defined in the exclude_patterns)
+    """
     if include_patterns is None:
         include_patterns = []
     os.makedirs(dst, exist_ok=True)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -126,6 +126,42 @@ def test_copy_files_excluding_pattern(tmpdir):
     assert len(results) == 3
 
 
+def test_copy_files_excluding_pattern_with_overriding_include_pattern(tmpdir):
+    """
+    Test the recursive copying of files from a source directory to a destination directory,
+    without excluding files that have been explicitly requested.
+
+    This test creates a temporary directory structure with several files, and multiple levels
+    then invokes the `copy_files_excluding_pattern` function to copy files from the source
+    directory to the destination directory while ignoring files and directories that match the
+    provided exclusion patterns.
+    """
+    root = os.path.join(tmpdir.strpath, "foo")
+    paths = [
+        os.path.join(root, "bar", "file.txt"),
+        os.path.join(root, "bar", "bad.txt"),
+        os.path.join(root, "baz", "file.txt"),
+        os.path.join(root, "bing", "bang", "bad.txt"),
+        os.path.join(root, "bing", "bang", "bong", "good.txt"),
+        os.path.join(root, "bing", "file.txt"),
+    ]
+    for p in paths:
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as f:
+            f.write("content")
+
+    dest = os.path.join(tmpdir.strpath, "dest")
+    ignore = ["bar/bad.txt", "bing/bang/*"]
+    include = ["bing/bang/bong*"]
+    distribution.copy_files_excluding_pattern(root, dest, ignore, include)
+
+    results = []
+    for _, _, files in os.walk(dest):
+        assert "bad.txt" not in files
+        results.extend(files)
+    assert len(results) == 4
+
+
 def test_remove_by_pattern(tmpdir):
     """
     Test the removal of all files/dirs from a higherarchy that match a passed glob pattern.
@@ -145,7 +181,37 @@ def test_remove_by_pattern(tmpdir):
         with open(p, "w") as f:
             f.write("content")
 
-    distribution.remove_by_pattern(f"{bad_root}/*")
+    distribution.remove_by_pattern(f"{bad_root}/*", [])
+
+    for bad_p in bad:
+        assert not os.path.isfile(bad_p)
+    for good_p in good:
+        assert os.path.isfile(good_p)
+    assert os.path.isdir(bad_root)
+
+
+def test_remove_by_pattern_with_overriding_incldues(tmpdir):
+    """
+    Test the removal of all files/dirs from a higherarchy that match a passed glob pattern,
+    but assert that any files specifeid in the include pattern do not get removed.
+    """
+    root = os.path.join(tmpdir.strpath, "foo")
+    bad_root = os.path.join(root, "bing")
+    bad = [os.path.join(bad_root, "bang", "bad.txt"), os.path.join(bad_root, "bing", "file.txt")]
+
+    good = [
+        os.path.join(root, "bar", "file.txt"),
+        os.path.join(root, "bar", "bong", "bad.txt"),
+        os.path.join(root, "baz", "file.txt"),
+        os.path.join(bad_root, "good", "file.txt"),
+    ]
+
+    for p in good + bad:
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as f:
+            f.write("content")
+
+    distribution.remove_by_pattern(f"{bad_root}/*", [f"{bad_root}/good*"])
 
     for bad_p in bad:
         assert not os.path.isfile(bad_p)
@@ -531,16 +597,21 @@ def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     pkgr.concretize()
     assert len(os.listdir(env_dir)) == 3
     bad_file = os.path.join(pkgr.spack_dir, "foo", "aFile")
+    good_file = os.path.join(pkgr.spack_dir, "foo", "bFile")
     os.makedirs(os.path.dirname(bad_file))
     with open(bad_file, "w") as out:
-        out.write("content")
-    monkeypatch.setattr(distribution, "SPACK_USER_PATTERNS", ["foo/*"])
-
+        out.write("acontent")
+    with open(good_file, "w") as out:
+        out.write("bcontent")
+    monkeypatch.setattr(distribution, "SPACK_USER_EXCLUDE_PATTERNS", ["foo/*"])
+    monkeypatch.setattr(distribution, "SPACK_USER_INCLUDE_PATTERNS", ["foo/bFile"])
     pkgr.remove_unwanted_artifacts()
+
     env_assets = os.listdir(env_dir)
     assert len(env_assets) == 1
     assert "spack.yaml" in env_assets
     assert not os.path.isfile(bad_file)
+    assert os.path.isfile(good_file)
 
 
 def test_DistributionPackager_configure_includes(tmpdir):
@@ -682,16 +753,18 @@ def test_DistributionPackager_configure_package_settings(tmpdir):
 
     inital_config = get_manifest(pkgr.env)
     assert "packages" not in inital_config["spack"]
-    pkgr.configure_package_settings(filter_externals=True)
+    pkgr.init_config()
+    result_config = get_manifest(pkgr.env)
+    assert good["all"]["prefer"] == result_config["spack"]["packages"]["all"]["prefer"]
+    assert "cmake" in result_config["spack"]["packages"]
+
+    pkgr.filter_exclude_configs(filter_externals=True)
     result_config = get_manifest(pkgr.env)
     assert "packages" in result_config["spack"]
-    assert good == result_config["spack"]["packages"]
-
-    pkgr.configure_package_settings(filter_externals=False)
-    new_result_config = get_manifest(pkgr.env)
-    new_expected = good.copy()
-    new_expected.update(bad)
-    assert new_expected == new_result_config["spack"]["packages"]
+    assert good["all"]["prefer"] == result_config["spack"]["packages"]["all"]["prefer"]
+    assert "cmake" not in result_config["spack"]["packages"]
+    # Make sure spack defaults are added to the packages dict
+    assert good != result_config["spack"]["packages"]
 
 
 def test_DistributionPackager_bundle_extra_data(tmpdir):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -190,7 +190,7 @@ def test_remove_by_pattern(tmpdir):
     assert os.path.isdir(bad_root)
 
 
-def test_remove_by_pattern_with_overriding_incldues(tmpdir):
+def test_remove_by_pattern_with_overriding_includes(tmpdir):
     """
     Test the removal of all files/dirs from a higherarchy that match a passed glob pattern,
     but assert that any files specifeid in the include pattern do not get removed.


### PR DESCRIPTION
The distribution capability was excluding spack's default settings from the generated environment.  This was due to inadequate inclusion of packages in the config and minssing assets in the included spack