### PR TITLE
Remove buildcache keys call from distribution command

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -385,7 +385,6 @@ class DistributionPackager:
         with self.environment_to_package:
             tty.msg(f"Creating binary mirror at {self.binary_mirror}....")
             call(spack.cmd.buildcache, "buildcache", ["push", "--unsigned", self.binary_mirror])
-            call(spack.cmd.buildcache, "buildcache", ["keys", "--install", "--trust"])
 
         mirror_path = os.path.join(
             os.path.relpath(self.path, self.env.path), os.path.basename(self.binary_mirror)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -927,8 +927,8 @@ def test_DistributionPackager_configure_binary_mirror(tmpdir, monkeypatch):
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_binary_mirror()
 
-    assert len(MockCommand.call_args) == 3
-    assert MockCommand.args == ["buildcache", "buildcache", "mirror"]
+    assert len(MockCommand.call_args) == 2
+    assert MockCommand.args == ["buildcache", "mirror"]
 
     buildcache_parser = ArgumentParser()
     test_buildcache_parse.setup_parser(buildcache_parser)
@@ -936,8 +936,7 @@ def test_DistributionPackager_configure_binary_mirror(tmpdir, monkeypatch):
     test_mirror_parse.setup_parser(mirror_parser)
     with pkgr.env:
         buildcache_parser.parse_args(MockCommand.call_args[0])
-        buildcache_parser.parse_args(MockCommand.call_args[1])
-        mirror_parser.parse_args(MockCommand.call_args[2])
+        mirror_parser.parse_args(MockCommand.call_args[1])
 
 
 def test_DistributionPackager_get_flattened_config(tmpdir):


### PR DESCRIPTION
In the distribution command, `configure_binary_mirror()` pushes with `--unsigned` but then calls `buildcache keys --install --trust`, which fails if no mirror is configured in the active environment's scope.

It exits before `bundle_spack()` runs, leaving an incomplete distro without the bundled Spack.

The keys call is unnecessary since there are no signatures to verify when pushing unsigned.

Tested with Spack 1.1.1.

```
  File "spack-manager/manager/manager_cmds/distribution.py", line 388, in configure_binary_mirror
    call(spack.cmd.buildcache, "buildcache", ["keys", "--install", "--trust"])
...
    spack.binary_distribution.get_keys(args.install, args.trust, args.force)
  File "spack/lib/spack/spack/binary_distribution.py", line 2213, in get_keys
    tty.die("Please add a spack mirror to allow " + "download of build caches.")
  File "spack/spack/lib/spack/spack/llnl/util/tty/__init__.py", line 249, in die
    sys.exit(1)
SystemExit: 1
```
