### PR TITLE
Distribution: Fix unable to bootstrap when an environment requires non-gcc/clang compilers

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -3,6 +3,7 @@ import fnmatch
 import glob
 import os
 import shutil
+import tempfile
 
 import spack.cmd
 import spack.cmd.add
@@ -16,6 +17,7 @@ import spack.extensions
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.spec
+import spack.solver.asp
 import spack.util.path
 import spack.util.spack_yaml
 from spack.paths import spack_root
@@ -400,10 +402,8 @@ class DistributionPackager:
                     ["add", "--type", "binary", "--unsigned", mirror_name, mirror_path],
                 )
 
-    def configure_bootstrap_mirror(self):
-        tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")
-
-        with self.environment_to_package:
+    def _create_bootstrap(self, env):
+        with env:
             call(
                 spack.cmd.bootstrap,
                 "bootstrap",
@@ -416,6 +416,18 @@ class DistributionPackager:
             bootstrap_binary = os.path.join(
                 os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "binaries"
             )
+        return bootstrap_source, bootstrap_binary
+
+    def configure_bootstrap_mirror(self):
+        tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")
+        try:
+            bootstrap_source, bootstrap_binary = self._create_bootstrap(self.environment_to_package)
+        except spack.solver.asp.UnsatisfiableSpecError:
+            tty.msg("Bootstrap miror creation failed, falling back to creating bootstrap mirror from a clean envionment")
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                temp_env = spack.environment.create_in_dir(tmpdir)
+                bootstrap_source, bootstrap_binary = self._create_bootstrap(temp_env)
 
         with self.env:
             with fs.working_dir(self.env.path):

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -16,8 +16,8 @@ import spack.environment
 import spack.extensions
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
-import spack.spec
 import spack.solver.asp
+import spack.spec
 import spack.util.path
 import spack.util.spack_yaml
 from spack.paths import spack_root
@@ -421,9 +421,11 @@ class DistributionPackager:
     def configure_bootstrap_mirror(self):
         tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")
         try:
-            bootstrap_source, bootstrap_binary = self._create_bootstrap(self.environment_to_package)
+            bootstrap_source, bootstrap_binary = self._create_bootstrap(
+                self.environment_to_package
+            )
         except spack.solver.asp.UnsatisfiableSpecError:
-            tty.msg("Bootstrap miror creation failed, falling back to creating bootstrap mirror from a clean envionment")
+            tty.msg("Bootstrap miror creation failed, re-attempting from a clean envionment")
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 temp_env = spack.environment.create_in_dir(tmpdir)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -915,8 +915,8 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
 ):
     """
     Test that a failure creating the bootstrap mirror falls back to using an empty environment
-    (generally this has been caused by overly-restrictive compiler settings, which don't really apply
-    for the bootstrap mirror).
+    (generally this has been caused by overly-restrictive compiler settings, which don't really
+    apply for the bootstrap mirror).
     """
     pkgr, root, env = init_test_environment(tmpdir.strpath)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -18,6 +18,7 @@ import spack.cmd.mirror as test_mirror_parse
 import spack.config
 import spack.environment
 import spack.extensions
+import spack.solver.asp
 import spack.spec
 import spack.util.spack_yaml
 
@@ -901,6 +902,35 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     pkgr.configure_bootstrap_mirror()
 
     assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap"]
+
+    parser = ArgumentParser()
+    test_bootstrap_parse.setup_parser(parser)
+    with pkgr.env:
+        for call in MockCommand.call_args:
+            parser.parse_args(call)
+
+
+def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(tmpdir, monkeypatch):
+    """
+    This test verifies that `configure_bootstrap_mirror` does not construct a call to
+    `spack bootstrap` that violates its API.
+    """
+    pkgr, root, env = init_test_environment(tmpdir.strpath)
+
+    class MockCommand:
+        args = []
+        call_args = []
+
+        def __init__(self, _, cmd, args):
+            self.args.append(cmd)
+            self.call_args.append(args)
+            if len(self.args) == 1:
+                raise spack.solver.asp.UnsatisfiableSpecError("fake error")
+
+    monkeypatch.setattr(distribution, "call", MockCommand)
+    pkgr.configure_bootstrap_mirror()
+
+    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "bootstrap"]
 
     parser = ArgumentParser()
     test_bootstrap_parse.setup_parser(parser)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -910,7 +910,9 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
             parser.parse_args(call)
 
 
-def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(tmpdir, monkeypatch):
+def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
+    tmpdir, monkeypatch
+):
     """
     This test verifies that `configure_bootstrap_mirror` does not construct a call to
     `spack bootstrap` that violates its API.

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -914,8 +914,9 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
     tmpdir, monkeypatch
 ):
     """
-    This test verifies that `configure_bootstrap_mirror` does not construct a call to
-    `spack bootstrap` that violates its API.
+    Test that a failure creating the bootstrap mirror falls back to using an empty environment
+    (generally this has been caused by overly-restrictive compiler settings, which don't really apply
+    for the bootstrap mirror).
     """
     pkgr, root, env = init_test_environment(tmpdir.strpath)
 


### PR DESCRIPTION
We ran into a problem creating a bootstrap mirror from an environment containing the following:
```
packages:
    c:
        require: intel-oneapi-compilers
    cxx:
        require: intel-oneapi-compilers
```
because clingo requires a gcc/clang compiler to build.  This change adds a fallback so that if the bootstrap mirror creation fails, it is re-attemepted in a temporary environemnt that does not contain any user-specified information.  This fix relies on spack finding a gcc compiler on the system that can be used to build clingo.