### PR TITLE
Copy bootstrap if possible

### DIFF
--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -10,6 +10,7 @@ This module is the top level and deals specifically with manipulating the config
 file.  The data from the configuration file is then available and immutable to all
 other modules.
 """
+
 import os
 
 import spack.llnl.util.filesystem as fs

--- a/manager/manager_cmds/analyze.py
+++ b/manager/manager_cmds/analyze.py
@@ -192,7 +192,8 @@ def graph_dot(specs, builder, visitor, depflag=dt.ALL, out=None):
 
 
 def analyze(parser, args):
-    env = spack.cmd.require_active_env(cmd_name=command_name)
+    env = spack.cmd.require_active_env(args)
+
     specs = env.concrete_roots()
 
     visitor = None

--- a/manager/manager_cmds/analyze.py
+++ b/manager/manager_cmds/analyze.py
@@ -158,7 +158,7 @@ class StatsGraphBuilder(DotGraphBuilder):
             y *= scale_factor
             fontsize *= scale_factor
         scale_str = f"width={x} height={y} fixedsize=true fontsize={fontsize}"
-        color_str = f'fillcolor="{color_compute if self.to_color else"lightblue"}"'
+        color_str = f'fillcolor="{color_compute if self.to_color else "lightblue"}"'
 
         return (node.dag_hash(), f'[label="{node.format("{name}")}", {color_str}, {scale_str}]')
 

--- a/manager/manager_cmds/binary_finder.py
+++ b/manager/manager_cmds/binary_finder.py
@@ -32,7 +32,7 @@ def setup_parser_args(subparser):
 
 
 def binary_finder(parser, args):
-    env = spack.cmd.require_active_env(cmd_name=command_name)
+    env = spack.cmd.require_active_env(args)
     hashes = env.all_hashes()
     n = len(hashes)
     # TODO clean misc cache

--- a/manager/manager_cmds/cli_config.py
+++ b/manager/manager_cmds/cli_config.py
@@ -9,6 +9,7 @@
 Implementations for interacting and editing the spack-manager YAML config from the
 command line interface
 """
+
 from ... import manager
 from .. import projects
 

--- a/manager/manager_cmds/create_env.py
+++ b/manager/manager_cmds/create_env.py
@@ -112,7 +112,7 @@ def setup_parser_args(sub_parser):
 
 def add_command(parser, command_dict):
     sub_parser = parser.add_parser(
-        "create-env", help="convenience script" " for setting up a spack environment"
+        "create-env", help="convenience script for setting up a spack environment"
     )
     setup_parser_args(sub_parser)
     command_dict["create-env"] = create_env

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -45,7 +45,7 @@ def _redundant_code_from_spack_develop(args):
     Re-use the path and spec checking from spack.cmd.develop
     https://github.com/spack/spack/blob/b56f464c29c3e316c3afbbde52bf2597ad5351f1/lib/spack/spack/cmd/develop.py#L65-L95
     """
-    env = spack.cmd.require_active_env(cmd_name="develop")
+    env = spack.cmd.require_active_env(args)
 
     if not args.spec:
         if args.clone is False:
@@ -111,6 +111,7 @@ def manager_develop(parser, args):
     gives the option to clone based on specific fork and branch
     """
 
+    args.subparser = parser
     clone, path = _redundant_code_from_spack_develop(args)
 
     if args.repo_branch and clone:

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -129,9 +129,7 @@ def manager_develop(parser, args):
 
 def add_command(parser, command_dict):
     subparser = parser.add_parser(
-        "develop",
-        help="a more intuitieve interface for " "spack develop",
-        conflict_handler="resolve",
+        "develop", help="a more intuitieve interface for spack develop", conflict_handler="resolve"
     )
     s_setup_parser(subparser)
     clone_group = subparser.add_mutually_exclusive_group()
@@ -153,7 +151,7 @@ def add_command(parser, command_dict):
         "--all-branches",
         required=False,
         action="store_true",
-        help="clone all branches " "of the repo",
+        help="clone all branches of the repo",
         default=False,
     )
     subparser.add_argument(

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -16,6 +16,7 @@ import spack.environment
 import spack.extensions
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
+import spack.main
 import spack.solver.asp
 import spack.spec
 import spack.util.path
@@ -164,13 +165,14 @@ def get_relative_paths(original_paths, env_path, dir_name):
     return new_path
 
 
-def call(module, method, args):
-    sargs = " ".join(args)
-    tty.msg(f"Executing: spack {method} {sargs}")
-    parser = argparse.ArgumentParser()
-    module.setup_parser(parser)
-    args = parser.parse_args(args)
-    callme = getattr(module, method)
+def call(module, cmd, argv):
+    argv = [cmd, *argv]
+    sargs = " ".join(argv)
+    tty.msg(f"Executing: spack {sargs}")
+    parser = spack.main.make_argument_parser()
+    parser.add_command(cmd)
+    args = parser.parse_args(argv)
+    callme = getattr(module, cmd)
     callme(parser, args)
 
 
@@ -514,7 +516,7 @@ def remove_by_pattern(exclude_pattern, include_patterns):
 
 
 def distribution(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="manager distribution")
+    env = spack.cmd.require_active_env(args)
     correct_mirror_args(env, args)
 
     packager = DistributionPackager(

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -1,9 +1,9 @@
-import argparse
 import fnmatch
 import glob
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
 import spack.cmd
 import spack.cmd.add
@@ -404,63 +404,78 @@ class DistributionPackager:
                     ["add", "--type", "binary", "--unsigned", mirror_name, mirror_path],
                 )
 
+    @staticmethod
+    def _get_existing_bootstrap_sources():
+        return spack.config.CONFIG.get("bootstrap", {}).copy()
+
     def _create_bootstrap(self, env):
         with env:
-            call(
-                spack.cmd.bootstrap,
-                "bootstrap",
-                ["mirror", "--binary-packages", self.bootstrap_mirror],
-            )
+            sources = []
+            bootstrap_data = self._get_existing_bootstrap_sources()
+            if bootstrap_data.get("sources"):
+                for source in bootstrap_data["sources"]:
+                    potential_path = Path(source.get("metadata", ""))
+                    if potential_path.is_dir():
+                        idx = potential_path.parts.index("metadata")
+                        root = Path(*potential_path.parts[:idx])
+                        remaining = potential_path.parts[idx:]
+                        tty.msg(f"Copying {root} to {self.bootstrap_mirror}")
+                        shutil.copytree(root, self.bootstrap_mirror, dirs_exist_ok=True)
+                        rel_path = os.path.join(
+                            os.path.relpath(self.bootstrap_mirror, self.env.path), *remaining
+                        )
+                        name = "internal-source" if "sources" in remaining else "internal-binary"
+                        sources.append((name, rel_path))
 
-            bootstrap_source = os.path.join(
-                os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "sources"
-            )
-            bootstrap_binary = os.path.join(
-                os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "binaries"
-            )
-        return bootstrap_source, bootstrap_binary
+            if not sources:
+                call(
+                    spack.cmd.bootstrap,
+                    "bootstrap",
+                    ["mirror", "--binary-packages", self.bootstrap_mirror],
+                )
+                bootstrap_source = os.path.join(
+                    os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "sources"
+                )
+                bootstrap_binary = os.path.join(
+                    os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "binaries"
+                )
+                sources.append(("internal-source", bootstrap_source))
+                sources.append(("internal-binary", bootstrap_binary))
+        return sources
 
     def configure_bootstrap_mirror(self):
         tty.msg(f"Creating bootstrap mirror at {self.bootstrap_mirror}....")
         try:
-            bootstrap_source, bootstrap_binary = self._create_bootstrap(
-                self.environment_to_package
-            )
+            bootstrap_sources = self._create_bootstrap(self.environment_to_package)
         except spack.solver.asp.UnsatisfiableSpecError:
             tty.msg("Bootstrap miror creation failed, re-attempting from a clean envionment")
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 temp_env = spack.environment.create_in_dir(tmpdir)
-                bootstrap_source, bootstrap_binary = self._create_bootstrap(temp_env)
+                bootstrap_sources = self._create_bootstrap(temp_env)
 
+        rel_mirror = os.path.relpath(self.bootstrap_mirror, self.env.path)
         with self.env:
             with fs.working_dir(self.env.path):
-                with self.env.write_transaction():
-                    call(
-                        spack.cmd.bootstrap,
-                        "bootstrap",
-                        [
-                            "add",
-                            "--trust",
-                            "--scope",
-                            f"env:{self.env.name}",
-                            "internal-sources",
-                            bootstrap_source,
-                        ],
-                    )
-                with self.env.write_transaction():
-                    call(
-                        spack.cmd.bootstrap,
-                        "bootstrap",
-                        [
-                            "add",
-                            "--trust",
-                            "--scope",
-                            f"env:{self.env.name}",
-                            "internal-binary",
-                            bootstrap_binary,
-                        ],
-                    )
+                for name, bootstrap_path in bootstrap_sources:
+                    with self.env.write_transaction():
+                        call(
+                            spack.cmd.bootstrap,
+                            "bootstrap",
+                            [
+                                "add",
+                                "--trust",
+                                "--scope",
+                                f"env:{self.env.name}",
+                                name,
+                                bootstrap_path,
+                            ],
+                        )
+                call(
+                    spack.cmd.buildcache,
+                    "buildcache",
+                    ["update-index", os.path.join(rel_mirror, "bootstrap_cache")],
+                )
 
     def bundle_spack(self):
         os.makedirs(self.path, exist_ok=True)

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -114,7 +114,7 @@ def external(parser, args):
     snap_env.check_views()
 
     if not snap_env.views:
-        tty.die("Environments used to create externals must have at least 1" " associated view")
+        tty.die("Environments used to create externals must have at least 1 associated view")
     # copy the file and overwrite any that may exist (or merge?)
     inc_name_abs = os.path.abspath(os.path.join(env.path, args.name))
 
@@ -147,23 +147,21 @@ def external(parser, args):
 
 def add_command(parser, command_dict):
     ext = parser.add_parser(
-        "external",
-        help="tools for configuring precompiled" " binaries",
-        conflict_handler="resolve",
+        "external", help="tools for configuring precompiled binaries", conflict_handler="resolve"
     )
 
     ext.add_argument(
         "-n",
         "--name",
         required=False,
-        help="name the new include file for the " "externals with this name",
+        help="name the new include file for the externals with this name",
     )
     ext.add_argument(
         "-m",
         "--merge",
         required=False,
         action="store_true",
-        help="merge existing yaml files " "together",
+        help="merge existing yaml files together",
     )
 
     select = ext.add_mutually_exclusive_group()
@@ -173,16 +171,16 @@ def add_command(parser, command_dict):
         "--include",
         nargs="*",
         required=False,
-        help="(not implemeted) specs that should " "be added (omit all others)",
+        help="(not implemeted) specs that should be added (omit all others)",
     )
     select.add_argument(
         "-e",
         "--exclude",
         nargs="*",
         required=False,
-        help="(not implemented) specs that should " "be omitted (add all others)",
+        help="(not implemented) specs that should be omitted (add all others)",
     )
-    ext.add_argument("path", nargs="?", help="The location of the external install " "directory")
+    ext.add_argument("path", nargs="?", help="The location of the external install directory")
     ext.set_defaults(merge=False, name="externals.yaml")
 
     command_dict["external"] = external

--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -133,8 +133,9 @@ def lock_diff(parser, args):
                         old_vars, new_vars
                     )
                 if old_spec.compiler_flags != new_spec.compiler_flags:
-                    old_flags, new_flags = str(old_spec.compiler_flags), str(
-                        new_spec.compiler_flags
+                    old_flags, new_flags = (
+                        str(old_spec.compiler_flags),
+                        str(new_spec.compiler_flags),
                     )
                     diff_msg += "\n *compiler_flags diff -\n\tOld {}\n\tNew: {}".format(
                         old_flags, new_flags

--- a/manager/manager_cmds/make.py
+++ b/manager/manager_cmds/make.py
@@ -46,7 +46,7 @@ def setup_parser(parser):
 
 
 def make(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="make")
+    env = spack.cmd.require_active_env(args)
     specs = spack.cmd.parse_specs(args.spec)
     if args.j:
         extra_make_args = [f"-j{args.j}"]

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -8,6 +8,7 @@
 """
 Functions for snapshot creation that are added here to be testable
 """
+
 import os
 
 import spack.cmd

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -140,7 +140,7 @@ def pin_env(parser, args):
     the dag, and then once after we replace the versions to make sure the environment
     still concretizes
     """
-    env = spack.cmd.require_active_env(cmd_name="pin")
+    env = spack.cmd.require_active_env(args)
 
     tty.debug("Pin: Pinning branches to sha's")
     pinRoot = args.roots or args.all

--- a/manager/manager_cmds/snapshot.py
+++ b/manager/manager_cmds/snapshot.py
@@ -140,16 +140,13 @@ def add_command(parser, command_dict):
         help="don't replace branch version with latest git hashes as verions",
     )
     sub_parser.add_argument(
-        "--name",
-        "-n",
-        required=False,
-        help="name the environment something other than the " "date",
+        "--name", "-n", required=False, help="name the environment something other than the date"
     )
     sub_parser.add_argument(
         "--use_machine_name",
         "-m",
         action="store_true",
-        help="use machine name in the snapshot path " "instead of computed architecture",
+        help="use machine name in the snapshot path instead of computed architecture",
     )
     sub_parser.add_argument(
         "-s", "--specs", required=True, default=[], nargs="+", help="Specs to create snapshots for"

--- a/scripts/recursive_develop.py
+++ b/scripts/recursive_develop.py
@@ -38,7 +38,7 @@ def develop_dependents(input, env, develop_args=[]):
 
 def main():
     args = parse_args()
-    env = spack.cmd.require_active_env(cmd_name="recursive")
+    env = spack.cmd.require_active_env(args)
     if args.forward:
         develop_args = args.forward.split()
     else:

--- a/tests/test_create_dev_env.py
+++ b/tests/test_create_dev_env.py
@@ -65,9 +65,7 @@ def test_newEnvironmentKeepingUserSpecifiedYAML(tmpdir, on_moonlight, monkeypatc
        path: {amr}
      nalu-wind:
        spec: nalu-wind@master
-       path: {nalu}""".format(
-            amr=amr_path.strpath, nalu=nalu_path.strpath
-        )
+       path: {nalu}""".format(amr=amr_path.strpath, nalu=nalu_path.strpath)
         with open(tmpdir.join("user.yaml"), "w") as yaml:
             yaml.write(user_spec_yaml)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -883,6 +883,144 @@ def test_DistributionPackager_configure_source_mirror_filter_specs(tmpdir, monke
             parser.parse_args(call)
 
 
+def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
+    if mirror_type == "sources":
+        expect_name = "source"
+    elif mirror_type == "binaries":
+        expect_name = "binary"
+
+    root = os.path.join(tmpdir.strpath, "root")
+    manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
+
+    # Create a fake bootstrap mirror structure on disk
+    # Structure: /tmp/fake_mirror/metadata/sources/...
+    fake_mirror_root = os.path.join(tmpdir.strpath, "fake_mirror")
+    metadata_dir = os.path.join(fake_mirror_root, "metadata")
+    sources_dir = os.path.join(metadata_dir, mirror_type)
+    os.makedirs(sources_dir)
+    with open(os.path.join(sources_dir, "some_data.yaml"), "w") as f:
+        f.write("data")
+
+    cache_dir = os.path.join(fake_mirror_root, "bootstrap_cache")
+    os.makedirs(cache_dir)
+    with open(os.path.join(cache_dir, "some_other_data.yaml"), "w") as f:
+        f.write("other data")
+
+    mock_bootstrap_config = {
+        "bootstrap": {"sources": [{"metadata": sources_dir, "name": "bootstrap-mirror-name"}]}
+    }
+
+    create_spack_manifest(manifest, extra_data=mock_bootstrap_config)
+    env = spack.environment.Environment(os.path.dirname(manifest))
+
+    pkgr = distribution.DistributionPackager(env, root)
+
+    mock_data = []
+
+    def mock_call(*args):
+        mock_data.append([*args[1:]])
+
+    monkeypatch.setattr(distribution, "call", mock_call)
+    pkgr.configure_bootstrap_mirror()
+
+    expected_args = [
+        [
+            "bootstrap",
+            [
+                "add",
+                "--trust",
+                "--scope",
+                f"env:{pkgr.env.path}",
+                f"internal-{expect_name}",
+                f"../bootstrap-mirror/metadata/{mirror_type}",
+            ],
+        ],
+        ["buildcache", ["update-index", "../bootstrap-mirror/bootstrap_cache"]],
+    ]
+    assert mock_data == expected_args
+    assert os.path.isfile(
+        os.path.join(pkgr.bootstrap_mirror, "metadata", mirror_type, "some_data.yaml")
+    )
+    assert os.path.isfile(
+        os.path.join(pkgr.bootstrap_mirror, "bootstrap_cache", "some_other_data.yaml")
+    )
+
+
+def test_DistributionPackager_create_bootstrap_with_existing_sources(tmpdir, monkeypatch):
+    """
+    Test that _create_bootstrap identifies existing bootstrap sources in the config,
+    copies the root directory of those sources, and returns the correct relative paths.
+    """
+    _assert_boostrap_copy_from_env(monkeypatch, tmpdir, "sources")
+
+
+def test_DistributionPackager_create_bootstrap_with_existing_binaries(tmpdir, monkeypatch):
+    """
+    Test that _create_bootstrap identifies existing bootstrap binaries in the config,
+    copies the root directory of those sources, and returns the correct relative paths.
+    """
+    _assert_boostrap_copy_from_env(monkeypatch, tmpdir, "binaries")
+
+
+def test_DistributionPackager_configure_bootstrap_mirror_calls_update_index(tmpdir, monkeypatch):
+    """
+    Test that configure_bootstrap_mirror calls 'spack buildcache update-index'
+    after adding the bootstrap sources.
+    """
+    pkgr, root, env = init_test_environment(tmpdir.strpath)
+
+    class MockCommand:
+        args = []
+        call_args = []
+
+        def __init__(self, _, cmd, args):
+            self.args.append(cmd)
+            self.call_args.append(args)
+
+    monkeypatch.setattr(distribution, "call", MockCommand)
+
+    # Mock _create_bootstrap to return a simple list
+    monkeypatch.setattr(pkgr, "_create_bootstrap", lambda e: [("internal-source", "some/path")])
+
+    pkgr.configure_bootstrap_mirror()
+
+    assert "buildcache" in MockCommand.args
+
+    update_index_called = False
+    for cmd, args in zip(MockCommand.args, MockCommand.call_args):
+        if cmd == "buildcache" and "update-index" in args:
+            update_index_called = True
+            assert "bootstrap_cache" in args[-1]
+
+    assert update_index_called
+
+
+def test_DistributionPackager_create_bootstrap_fallback(tmpdir, monkeypatch):
+    """
+    Test that if no bootstrap sources are found in config, it falls back to
+    the 'bootstrap mirror' command and returns default internal-source/binary paths.
+    """
+    root = os.path.join(tmpdir.strpath, "root")
+    manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
+    create_spack_manifest(manifest)
+    env = spack.environment.Environment(os.path.dirname(manifest))
+
+    def mock_call(*args):
+        pass
+
+    monkeypatch.setattr(distribution, "call", mock_call)
+
+    pkgr = distribution.DistributionPackager(env, root)
+    pkgr.bootstrap_mirror = os.path.join(root, "bootstrap-mirror")
+
+    sources = pkgr._create_bootstrap(env)
+
+    assert len(sources) == 2
+    names = [s[0] for s in sources]
+    assert "internal-source" in names
+    assert "internal-binary" in names
+
+
 def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     """
     This test verifies that `configure_bootstrap_mirror` does not construct a call to
@@ -901,13 +1039,16 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_bootstrap_mirror()
 
-    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap"]
+    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "buildcache"]
 
-    parser = ArgumentParser()
-    test_bootstrap_parse.setup_parser(parser)
+    boostrap_parser = ArgumentParser()
+    test_bootstrap_parse.setup_parser(boostrap_parser)
+    buildcache_parser = ArgumentParser()
+    test_buildcache_parse.setup_parser(buildcache_parser)
+    parsers = {"bootstrap": boostrap_parser, "buildcache": buildcache_parser}
     with pkgr.env:
-        for call in MockCommand.call_args:
-            parser.parse_args(call)
+        for i, call in enumerate(MockCommand.call_args):
+            parsers[MockCommand.args[i]].parse_args(call)
 
 
 def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
@@ -933,13 +1074,16 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_bootstrap_mirror()
 
-    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "bootstrap"]
+    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "bootstrap", "buildcache"]
 
-    parser = ArgumentParser()
-    test_bootstrap_parse.setup_parser(parser)
+    boostrap_parser = ArgumentParser()
+    test_bootstrap_parse.setup_parser(boostrap_parser)
+    buildcache_parser = ArgumentParser()
+    test_buildcache_parse.setup_parser(buildcache_parser)
+    parsers = {"bootstrap": boostrap_parser, "buildcache": buildcache_parser}
     with pkgr.env:
-        for call in MockCommand.call_args:
-            parser.parse_args(call)
+        for i, call in enumerate(MockCommand.call_args):
+            parsers[MockCommand.args[i]].parse_args(call)
 
 
 def test_DistributionPackager_configure_binary_mirror(tmpdir, monkeypatch):

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -25,7 +25,7 @@ manager = spack.main.SpackCommand("manager")
     "spec_str",
     [
         "amr-wind@main dev_path=/amr-wind",
-        "nalu-wind@master+cuda cuda_arch=70 " "dev_path=/nalu-wind",
+        "nalu-wind@master+cuda cuda_arch=70 dev_path=/nalu-wind",
         "exawind@master dev_path=/exawind "
         "^nalu-wind@master dev_path=/nalu-wind"
         " ^amr-wind@main dev_path=/amr-wind",
@@ -42,7 +42,7 @@ def test_stripDevPathFromExternals(spec_str):
     "spec_str",
     [
         "amr-wind@main patches=abscdef",
-        "nalu-wind@master+cuda cuda_arch=70 " "patches=asldfkjas",
+        "nalu-wind@master+cuda cuda_arch=70 patches=asldfkjas",
         "exawind@master patches=fxfdcx "
         "^nalu-wind@master patches=dtafwuf"
         " ^amr-wind@main patches=windenergy",
@@ -85,9 +85,7 @@ class ParserMock:
 def setupExternalEnv(tmpdir, has_view=True):
     yaml_file = """spack:
   view: {v}
-  specs: [cmake@3.20.0]""".format(
-        v=has_view
-    )
+  specs: [cmake@3.20.0]""".format(v=has_view)
     env_path = str(tmpdir.join("external"))
     os.makedirs(env_path, exist_ok=True)
     os.makedirs(str(tmpdir.join("test")), exist_ok=True)
@@ -138,9 +136,7 @@ class ExtPackage:
     - spec: {spec}
       prefix: {prefix}
     buildable: False
-""".format(
-            name=name, spec=spec, prefix=prefix
-        )
+""".format(name=name, spec=spec, prefix=prefix)
 
     def __str__(self):
         return self.package_str


### PR DESCRIPTION
Add a check for existing bootstrap mirror. If the source environment has a bootstrap mirror, copy it and register it in the distribution bundle's environment instead of creating a new one.  This allows the creation of distribution bundles in air-gaped environments.