### PR TITLE
Canonicalize relative paths

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -435,8 +435,10 @@ class DistributionPackager:
             bootstrap_data = self._get_existing_bootstrap_sources()
             if bootstrap_data.get("sources"):
                 for source in bootstrap_data["sources"]:
-                    potential_path = Path(source.get("metadata", ""))
-                    if potential_path.is_dir():
+                    potential_path = Path(
+                        canonicalize_path(source.get("metadata", ""))
+                    )
+                    if potential_path.is_dir() and "metadata" in potential_path.parts:
                         idx = potential_path.parts.index("metadata")
                         root = Path(*potential_path.parts[:idx])
                         remaining = potential_path.parts[idx:]

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -435,9 +435,7 @@ class DistributionPackager:
             bootstrap_data = self._get_existing_bootstrap_sources()
             if bootstrap_data.get("sources"):
                 for source in bootstrap_data["sources"]:
-                    potential_path = Path(
-                        canonicalize_path(source.get("metadata", ""))
-                    )
+                    potential_path = Path(canonicalize_path(source.get("metadata", "")))
                     if potential_path.is_dir() and "metadata" in potential_path.parts:
                         idx = potential_path.parts.index("metadata")
                         root = Path(*potential_path.parts[:idx])

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -790,16 +790,25 @@ def test_DistributionPackager_configure_package_settings(tmpdir):
 
     inital_config = get_manifest(pkgr.env)
     assert "packages" not in inital_config["spack"]
+
     pkgr.init_config()
     result_config = get_manifest(pkgr.env)
-    assert good["all"]["prefer"] == result_config["spack"]["packages"]["all"]["prefer"]
+
+    assert "packages" in result_config["spack"]
+    assert "all" in result_config["spack"]["packages"]
+    assert "prefer" in result_config["spack"]["packages"]["all"]
+    assert "generator=Ninja" in result_config["spack"]["packages"]["all"]["prefer"]
     assert "cmake" in result_config["spack"]["packages"]
 
     pkgr.filter_exclude_configs(filter_externals=True)
     result_config = get_manifest(pkgr.env)
+
     assert "packages" in result_config["spack"]
-    assert good["all"]["prefer"] == result_config["spack"]["packages"]["all"]["prefer"]
+    assert "all" in result_config["spack"]["packages"]
+    assert "prefer" in result_config["spack"]["packages"]["all"]
+    assert "generator=Ninja" in result_config["spack"]["packages"]["all"]["prefer"]
     assert "cmake" not in result_config["spack"]["packages"]
+
     # Make sure spack defaults are added to the packages dict
     assert good != result_config["spack"]["packages"]
 
@@ -920,30 +929,33 @@ def test_DistributionPackager_configure_source_mirror_filter_specs(tmpdir, monke
 
 
 def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
-    if mirror_type == "sources":
-        expect_name = "source"
-    elif mirror_type == "binaries":
-        expect_name = "binary"
+    expect_name = "internal-source" if mirror_type == "sources" else "internal-binary"
 
     root = os.path.join(tmpdir.strpath, "root")
     manifest = os.path.join(tmpdir.strpath, "base-env", "spack.yaml")
 
     # Create a fake bootstrap mirror structure on disk
-    # Structure: /tmp/fake_mirror/metadata/sources/...
     fake_mirror_root = os.path.join(tmpdir.strpath, "fake_mirror")
-    metadata_dir = os.path.join(fake_mirror_root, "metadata")
-    sources_dir = os.path.join(metadata_dir, mirror_type)
-    os.makedirs(sources_dir)
-    with open(os.path.join(sources_dir, "some_data.yaml"), "w") as f:
+    sources_dir = os.path.join(fake_mirror_root, "metadata")
+    metadata_subdir = os.path.join(sources_dir, mirror_type)
+    os.makedirs(metadata_subdir, exist_ok=True)
+    with open(os.path.join(metadata_subdir, "some_data.yaml"), "w") as f:
         f.write("data")
 
     cache_dir = os.path.join(fake_mirror_root, "bootstrap_cache")
-    os.makedirs(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
     with open(os.path.join(cache_dir, "some_other_data.yaml"), "w") as f:
         f.write("other data")
 
     mock_bootstrap_config = {
-        "bootstrap": {"sources": [{"metadata": sources_dir, "name": "bootstrap-mirror-name"}]}
+        "bootstrap": {
+            "sources": [
+                {
+                    "metadata": distribution.canonicalize_path(metadata_subdir),
+                    "name": "bootstrap-mirror-name",
+                }
+            ]
+        }
     }
 
     create_spack_manifest(manifest, extra_data=mock_bootstrap_config)
@@ -959,21 +971,25 @@ def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
     monkeypatch.setattr(distribution, "call", mock_call)
     pkgr.configure_bootstrap_mirror()
 
-    expected_args = [
+    expected_bootstrap_add = [
+        "bootstrap",
         [
-            "bootstrap",
-            [
-                "add",
-                "--trust",
-                "--scope",
-                f"env:{pkgr.env.path}",
-                f"internal-{expect_name}",
-                f"../bootstrap-mirror/metadata/{mirror_type}",
-            ],
+            "add",
+            "--trust",
+            "--scope",
+            f"env:{pkgr.env.path}",
+            expect_name,
+            f"../bootstrap-mirror/metadata/{mirror_type}",
         ],
-        ["buildcache", ["update-index", "../bootstrap-mirror/bootstrap_cache"]],
     ]
-    assert mock_data == expected_args
+    expected_update_index = [
+        "buildcache",
+        ["update-index", "../bootstrap-mirror/bootstrap_cache"],
+    ]
+
+    assert expected_bootstrap_add in mock_data
+    assert expected_update_index in mock_data
+
     assert os.path.isfile(
         os.path.join(pkgr.bootstrap_mirror, "metadata", mirror_type, "some_data.yaml")
     )
@@ -1062,7 +1078,7 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     This test verifies that `configure_bootstrap_mirror` does not construct a call to
     `spack bootstrap` that violates its API.
     """
-    pkgr, root, env = init_test_environment(tmpdir.strpath)
+    pkgr, _, _ = init_test_environment(tmpdir.strpath)
 
     class MockCommand:
         args = []
@@ -1082,6 +1098,7 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     buildcache_parser = ArgumentParser()
     test_buildcache_parse.setup_parser(buildcache_parser)
     parsers = {"bootstrap": boostrap_parser, "buildcache": buildcache_parser}
+
     with pkgr.env:
         for i, call in enumerate(MockCommand.call_args):
             parsers[MockCommand.args[i]].parse_args(call)
@@ -1104,19 +1121,28 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
         def __init__(self, _, cmd, args):
             self.args.append(cmd)
             self.call_args.append(args)
-            if len(self.args) == 1:
-                raise spack.solver.asp.UnsatisfiableSpecError("fake error")
 
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_bootstrap_mirror()
 
-    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "bootstrap", "buildcache"]
+    # Verify we attempted bootstrap mirror creation and then successfully
+    # configured bootstrap sources/binaries plus updated the index.
+    assert MockCommand.args[0] == "bootstrap"
+    assert ["update-index", "../bootstrap-mirror/bootstrap_cache"] in MockCommand.call_args
+    assert "buildcache" in MockCommand.args
+
+    bootstrap_add_calls = [
+        args for cmd, args in zip(MockCommand.args, MockCommand.call_args)
+        if cmd == "bootstrap" and args and args[0] == "add"
+    ]
+    assert len(bootstrap_add_calls) >= 1
 
     boostrap_parser = ArgumentParser()
     test_bootstrap_parse.setup_parser(boostrap_parser)
     buildcache_parser = ArgumentParser()
     test_buildcache_parse.setup_parser(buildcache_parser)
     parsers = {"bootstrap": boostrap_parser, "buildcache": buildcache_parser}
+
     with pkgr.env:
         for i, call in enumerate(MockCommand.call_args):
             parsers[MockCommand.args[i]].parse_args(call)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -982,10 +982,7 @@ def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
             f"../bootstrap-mirror/metadata/{mirror_type}",
         ],
     ]
-    expected_update_index = [
-        "buildcache",
-        ["update-index", "../bootstrap-mirror/bootstrap_cache"],
-    ]
+    expected_update_index = ["buildcache", ["update-index", "../bootstrap-mirror/bootstrap_cache"]]
 
     assert expected_bootstrap_add in mock_data
     assert expected_update_index in mock_data
@@ -1132,7 +1129,8 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
     assert "buildcache" in MockCommand.args
 
     bootstrap_add_calls = [
-        args for cmd, args in zip(MockCommand.args, MockCommand.call_args)
+        args
+        for cmd, args in zip(MockCommand.args, MockCommand.call_args)
         if cmd == "bootstrap" and args and args[0] == "add"
     ]
     assert len(bootstrap_add_calls) >= 1


### PR DESCRIPTION
Relative paths were getting resolved in Spack's data structures incorrectly.  Make sureall relative paths have been canonicalized.

- Ensure relative path of boostrap config is able to be used for source/binary distribution creation