### PR TITLE
Revert "Preserve lockfile in distribution"

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -244,15 +244,9 @@ class DistributionPackager:
         os.makedirs(self.path)
 
     def concretize(self):
-        src_lock = self.environment_to_package.lock_path
-        dst_lock = self.env.lock_path
-        if os.path.isfile(src_lock):
-            tty.msg(f"Copying lockfile from {self.environment_to_package.name} to bundled env....")
-            shutil.copy2(src_lock, dst_lock)
-        else:
-            tty.msg(f"Concretizing env: {self.env.name}....")
-            self.env.concretize(force=True)
-            self.env.write()
+        tty.msg(f"Concretizing env: {self.env.name}....")
+        self.env.concretize(force=True)
+        self.env.write()
 
     def remove_unwanted_artifacts(self):
         include_patterns = [
@@ -263,7 +257,7 @@ class DistributionPackager:
                 remove_by_pattern(os.path.join(self.spack_dir, epattern), include_patterns)
         for item in os.listdir(self.env.path):
             fullname = os.path.join(self.env.path, item)
-            if "spack.yaml" in item or "spack.lock" in item:
+            if "spack.yaml" in item:
                 continue
             elif os.path.isdir(fullname):
                 shutil.rmtree(fullname)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -566,7 +566,7 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_config(tmpdir
 def test_concretize(tmpdir):
     """
     This test verifies that `concretize` method calls env.concretize() on the
-    environment being created when the source env has no lockfile.
+    environment being created.
     """
     root = os.path.join(tmpdir.strpath, "root")
     manifest = os.path.join(root, "environment", "spack.yaml")
@@ -574,43 +574,12 @@ def test_concretize(tmpdir):
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
 
-    src_dir = os.path.join(tmpdir.strpath, "src")
-    create_spack_manifest(os.path.join(src_dir, "spack.yaml"))
-    src_env = get_fake_concretize_env(src_dir)
-
-    pkgr = distribution.DistributionPackager(src_env, root)
+    pkgr = distribution.DistributionPackager(None, root)
     pkgr._env = env
 
     pkgr.concretize()
     lockfile = os.path.join(env_dir, "spack.lock")
     assert os.path.isfile(lockfile)
-
-
-def test_concretize_copies_source_lockfile(tmpdir):
-    """
-    When the source env has a spack.lock, concretize() copies it into the
-    bundled env instead of re-concretizing.
-    """
-    root = os.path.join(tmpdir.strpath, "root")
-    manifest = os.path.join(root, "environment", "spack.yaml")
-    create_spack_manifest(manifest)
-    env_dir = os.path.dirname(manifest)
-    env = get_fake_concretize_env(env_dir)
-
-    src_dir = os.path.join(tmpdir.strpath, "src")
-    create_spack_manifest(os.path.join(src_dir, "spack.yaml"))
-    src_env = get_fake_concretize_env(src_dir)
-    with open(os.path.join(src_dir, "spack.lock"), "w") as f:
-        f.write("source-lockfile-contents")
-
-    pkgr = distribution.DistributionPackager(src_env, root)
-    pkgr._env = env
-
-    pkgr.concretize()
-    lockfile = os.path.join(env_dir, "spack.lock")
-    assert os.path.isfile(lockfile)
-    with open(lockfile) as f:
-        assert f.read() == "source-lockfile-contents"
 
 
 def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
@@ -624,11 +593,7 @@ def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     env_dir = os.path.dirname(manifest)
     env = get_fake_concretize_env(env_dir)
 
-    src_dir = os.path.join(tmpdir.strpath, "src")
-    create_spack_manifest(os.path.join(src_dir, "spack.yaml"))
-    src_env = get_fake_concretize_env(src_dir)
-
-    pkgr = distribution.DistributionPackager(src_env, root)
+    pkgr = distribution.DistributionPackager(None, root)
     pkgr._env = env
     pkgr.concretize()
     assert len(os.listdir(env_dir)) == 3
@@ -644,9 +609,8 @@ def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     pkgr.remove_unwanted_artifacts()
 
     env_assets = os.listdir(env_dir)
-    assert len(env_assets) == 2
+    assert len(env_assets) == 1
     assert "spack.yaml" in env_assets
-    assert "spack.lock" in env_assets
     assert not os.path.isfile(bad_file)
     assert os.path.isfile(good_file)
 


### PR DESCRIPTION
Reverts sandialabs/spack-manager#650

I had to revert this @rtrigg.  In my local testing it looked great, but I over looked a use-case.  When the distribution command is called with the `--filter-externals` command, the tool modifies the new environment.  When that happens we have to reconcretize in order to have those environment changes reflected in the final package that gets created.