### PR TITLE
Set concretization_cache to false in distribution.py to avoid hang during concretization

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -244,6 +244,7 @@ class DistributionPackager:
         os.makedirs(self.path)
 
     def concretize(self):
+        spack.config.add("concretizer:concretization_cache:enable:false")
         tty.msg(f"Concretizing env: {self.env.name}....")
         self.env.concretize(force=True)
         self.env.write()

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -580,6 +580,7 @@ def test_concretize(tmpdir):
     pkgr.concretize()
     lockfile = os.path.join(env_dir, "spack.lock")
     assert os.path.isfile(lockfile)
+    assert spack.config.get("concretizer:concretization_cache:enable") is False
 
 
 def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):


### PR DESCRIPTION
We have observed that a new update to Spack causes a hang during the concretization of the created distribution.py spack environment if the environment that is created has a large amount of packages and the concretization tree is very large. To fix this, setting the `concretization_cache` to false right before concretizting the new environment resolves the hang.