### PR TITLE
Use ignore_errors=True to skip NFS dir deletion issues using distribution.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -16,7 +16,10 @@ import importlib.util
 import os
 import sys
 
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.main
 
 spec = importlib.util.spec_from_file_location(

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -74,7 +74,9 @@ def remove_project_via_path(path):
         config_yaml["spack-manager"]["projects"].remove(path)
         write_config()
     else:
-        raise MissingProjectException("No project is registered with the path {0}".format(path))
+        raise MissingProjectException(
+            "No project is registered with the path {0}".format(path)
+        )
 
 
 def remove_project_via_index(index):
@@ -83,7 +85,9 @@ def remove_project_via_index(index):
         config_yaml["spack-manager"]["projects"].pop(index)
         write_config()
     else:
-        raise MissingProjectException("No project is registered with the index {0}".format(index))
+        raise MissingProjectException(
+            "No project is registered with the index {0}".format(index)
+        )
 
 
 def initialize():

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -17,9 +17,9 @@ import spack.llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
 
 try:
-    import spack.util.filesystem as fs
-except ImportError:
     import spack.llnl.util.filesystem as fs
+except ImportError:
+    import spack.util.filesystem as fs
 
 
 _default_config = """

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -13,13 +13,14 @@ other modules.
 
 import os
 
-import spack.llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
 
 try:
     import spack.llnl.util.filesystem as fs
+    import spack.llnl.util.tty as tty
 except ImportError:
     import spack.util.filesystem as fs
+    import spack.util.tty as tty
 
 
 _default_config = """

--- a/manager/cmd/manager.py
+++ b/manager/cmd/manager.py
@@ -37,7 +37,9 @@ _subcommands = {}
 
 
 def setup_parser(subparser):
-    sp = subparser.add_subparsers(metavar="spack-manager commands", dest="manager_command")
+    sp = subparser.add_subparsers(
+        metavar="spack-manager commands", dest="manager_command"
+    )
 
     cli_config.cli_commands["add"](sp, _subcommands)
     cli_config.cli_commands["remove"](sp, _subcommands)

--- a/manager/manager_cmds/analyze.py
+++ b/manager/manager_cmds/analyze.py
@@ -60,13 +60,17 @@ def setup_parser_args(subparser):
         help="clip the graph at nodes that satisfy these specs",
     )
     visitor_types.add_argument(
-        "--require-attribute", "-r", help="only include packages that have this package attribute"
+        "--require-attribute",
+        "-r",
+        help="only include packages that have this package attribute",
     )
     subparser.add_argument(
         "--stats", action="store_true", help="display stats for graph build/install"
     )
     subparser.add_argument(
-        "--graph", action="store_true", help="generate a dot file of the graph requested"
+        "--graph",
+        action="store_true",
+        help="generate a dot file of the graph requested",
     )
     subparser.add_argument(
         "--scale-nodes",
@@ -75,12 +79,17 @@ def setup_parser_args(subparser):
         help="scale graph nodes relative to the mean install time",
     )
     subparser.add_argument(
-        "--color", "-c", action="store_true", help="color graph nodes based on the time to build"
+        "--color",
+        "-c",
+        action="store_true",
+        help="color graph nodes based on the time to build",
     )
 
 
 def traverse_nodes_with_visitor(specs, visitor):
-    traverse.traverse_breadth_first_with_visitor(specs, traverse.CoverNodesVisitor(visitor))
+    traverse.traverse_breadth_first_with_visitor(
+        specs, traverse.CoverNodesVisitor(visitor)
+    )
     return visitor.accepted
 
 
@@ -160,7 +169,10 @@ class StatsGraphBuilder(DotGraphBuilder):
         scale_str = f"width={x} height={y} fixedsize=true fontsize={fontsize}"
         color_str = f'fillcolor="{color_compute if self.to_color else "lightblue"}"'
 
-        return (node.dag_hash(), f'[label="{node.format("{name}")}", {color_str}, {scale_str}]')
+        return (
+            node.dag_hash(),
+            f'[label="{node.format("{name}")}", {color_str}, {scale_str}]',
+        )
 
     def edge_entry(self, edge):
         return (edge.parent.dag_hash(), edge.spec.dag_hash(), None)

--- a/manager/manager_cmds/create_env.py
+++ b/manager/manager_cmds/create_env.py
@@ -23,7 +23,9 @@ from spack.extensions.manager.manager_cmds.location import location
 
 def create_env(parser, args):
     if args.name is not None:
-        theDir = environment.create(args.name, init_file=args.yaml, keep_relative=True).path
+        theDir = environment.create(
+            args.name, init_file=args.yaml, keep_relative=True
+        ).path
     else:
         if args.directory is not None:
             if os.path.exists(args.directory) is False:
@@ -69,7 +71,9 @@ def create_env(parser, args):
 
 
 def setup_parser_args(sub_parser):
-    sub_parser.add_argument("-m", "--machine", required=False, help="Machine to match configs")
+    sub_parser.add_argument(
+        "-m", "--machine", required=False, help="Machine to match configs"
+    )
     sub_parser.add_argument(
         "-p",
         "--project",

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -9,7 +9,10 @@ import os
 import shutil
 
 import spack.cmd
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.util.executable
 from spack.cmd.develop import develop as s_develop
 from spack.cmd.develop import setup_parser as s_setup_parser

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -9,6 +9,7 @@ import os
 import shutil
 
 import spack.cmd
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:
@@ -133,7 +134,9 @@ def manager_develop(parser, args):
 
 def add_command(parser, command_dict):
     subparser = parser.add_parser(
-        "develop", help="a more intuitieve interface for spack develop", conflict_handler="resolve"
+        "develop",
+        help="a more intuitieve interface for spack develop",
+        conflict_handler="resolve",
     )
     s_setup_parser(subparser)
     clone_group = subparser.add_mutually_exclusive_group()

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -244,6 +244,7 @@ class DistributionPackager:
         os.makedirs(self.path)
 
     def concretize(self):
+        spack.config.add("concretizer:concretization_cache:enable:false")
         tty.msg(f"Concretizing env: {self.env.name}....")
         self.env.concretize(force=True)
         self.env.write()

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -16,9 +16,9 @@ import spack.environment
 import spack.extensions
 
 try:
-    import spack.util.filesystem as fs
-except ImportError:
     import spack.llnl.util.filesystem as fs
+except ImportError:
+    import spack.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.main
 import spack.solver.asp

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -47,7 +47,8 @@ def add_command(parser, command_dict):
         help="Directory where the packaged environment should be created",
     )
     subparser.add_argument(
-        "--include", help="Directory containing yaml to be included in the packaged environment"
+        "--include",
+        help="Directory containing yaml to be included in the packaged environment",
     )
     subparser.add_argument(
         "--exclude-configs",
@@ -192,6 +193,7 @@ def call(module, cmd, argv):
     callme = getattr(module, cmd)
     callme(parser, args)
 
+
 def contains_only_nfs_file(path):
     for root, dirs, files in os.walk(path):
         for name in files:
@@ -202,7 +204,13 @@ def contains_only_nfs_file(path):
 
 class DistributionPackager:
     def __init__(
-        self, env, root, includes=None, exclude_configs=None, exclude_file=None, extra_data=None
+        self,
+        env,
+        root,
+        includes=None,
+        exclude_configs=None,
+        exclude_file=None,
+        extra_data=None,
     ):
         self.environment_to_package = env
         self.includes = includes
@@ -260,11 +268,14 @@ class DistributionPackager:
 
     def remove_unwanted_artifacts(self):
         include_patterns = [
-            os.path.join(self.spack_dir, ipattern) for ipattern in SPACK_USER_INCLUDE_PATTERNS
+            os.path.join(self.spack_dir, ipattern)
+            for ipattern in SPACK_USER_INCLUDE_PATTERNS
         ]
         for epattern in SPACK_USER_EXCLUDE_PATTERNS:
             for ipattern in SPACK_USER_INCLUDE_PATTERNS:
-                remove_by_pattern(os.path.join(self.spack_dir, epattern), include_patterns)
+                remove_by_pattern(
+                    os.path.join(self.spack_dir, epattern), include_patterns
+                )
         for item in os.listdir(self.env.path):
             fullname = os.path.join(self.env.path, item)
             if "spack.yaml" in item:
@@ -310,7 +321,9 @@ class DistributionPackager:
                 if flattened_config[section]:
                     try:
                         spack.config.CONFIG.set(
-                            section, flattened_config[section], scope=self.env.scope_name
+                            section,
+                            flattened_config[section],
+                            scope=self.env.scope_name,
                         )
                     except spack.config.ConfigFormatError as e:
                         tty.error(
@@ -332,7 +345,11 @@ class DistributionPackager:
                 for package in packages:
                     if "externals" in packages[package]:
                         with self.env.write_transaction():
-                            call(spack.cmd.config, "config", ["remove", f"packages:{package}"])
+                            call(
+                                spack.cmd.config,
+                                "config",
+                                ["remove", f"packages:{package}"],
+                            )
 
     def configure_includes(self):
         if self.includes:
@@ -410,19 +427,27 @@ class DistributionPackager:
             call(spack.cmd.mirror, "mirror", args)
 
             mirror_path = os.path.join(
-                os.path.relpath(self.path, self.env.path), os.path.basename(self.source_mirror)
+                os.path.relpath(self.path, self.env.path),
+                os.path.basename(self.source_mirror),
             )
             tty.msg(f"Adding mirror to env: {self.env.name}....")
             with self.env.write_transaction():
-                call(spack.cmd.mirror, "mirror", ["add", "internal-source", mirror_path])
+                call(
+                    spack.cmd.mirror, "mirror", ["add", "internal-source", mirror_path]
+                )
 
     def configure_binary_mirror(self):
         with self.environment_to_package:
             tty.msg(f"Creating binary mirror at {self.binary_mirror}....")
-            call(spack.cmd.buildcache, "buildcache", ["push", "--unsigned", self.binary_mirror])
+            call(
+                spack.cmd.buildcache,
+                "buildcache",
+                ["push", "--unsigned", self.binary_mirror],
+            )
 
         mirror_path = os.path.join(
-            os.path.relpath(self.path, self.env.path), os.path.basename(self.binary_mirror)
+            os.path.relpath(self.path, self.env.path),
+            os.path.basename(self.binary_mirror),
         )
         mirror_name = "internal-binary"
 
@@ -453,9 +478,14 @@ class DistributionPackager:
                         tty.msg(f"Copying {root} to {self.bootstrap_mirror}")
                         shutil.copytree(root, self.bootstrap_mirror, dirs_exist_ok=True)
                         rel_path = os.path.join(
-                            os.path.relpath(self.bootstrap_mirror, self.env.path), *remaining
+                            os.path.relpath(self.bootstrap_mirror, self.env.path),
+                            *remaining,
                         )
-                        name = "internal-source" if "sources" in remaining else "internal-binary"
+                        name = (
+                            "internal-source"
+                            if "sources" in remaining
+                            else "internal-binary"
+                        )
                         sources.append((name, rel_path))
 
             if not sources:
@@ -465,10 +495,14 @@ class DistributionPackager:
                     ["mirror", "--binary-packages", self.bootstrap_mirror],
                 )
                 bootstrap_source = os.path.join(
-                    os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "sources"
+                    os.path.relpath(self.bootstrap_mirror, self.env.path),
+                    "metadata",
+                    "sources",
                 )
                 bootstrap_binary = os.path.join(
-                    os.path.relpath(self.bootstrap_mirror, self.env.path), "metadata", "binaries"
+                    os.path.relpath(self.bootstrap_mirror, self.env.path),
+                    "metadata",
+                    "binaries",
                 )
                 sources.append(("internal-source", bootstrap_source))
                 sources.append(("internal-binary", bootstrap_binary))
@@ -479,7 +513,9 @@ class DistributionPackager:
         try:
             bootstrap_sources = self._create_bootstrap(self.environment_to_package)
         except spack.solver.asp.UnsatisfiableSpecError:
-            tty.msg("Bootstrap miror creation failed, re-attempting from a clean envionment")
+            tty.msg(
+                "Bootstrap miror creation failed, re-attempting from a clean envionment"
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 temp_env = spack.environment.create_in_dir(tmpdir)
@@ -512,7 +548,12 @@ class DistributionPackager:
         os.makedirs(self.path, exist_ok=True)
         spack_install = os.path.join(self.path, "spack")
         tty.msg(f"Packing up Spack installation to {spack_install}....")
-        ignore_these = ["var/spack/environments/*", "opt/*", ".git*", "etc/spack/include.yaml"]
+        ignore_these = [
+            "var/spack/environments/*",
+            "opt/*",
+            ".git*",
+            "etc/spack/include.yaml",
+        ]
         copy_files_excluding_pattern(spack_root, spack_install, ignore_these)
 
     def bundle_extra_data(self):
@@ -535,10 +576,14 @@ def is_installed(spec):
 
 def correct_mirror_args(env, args):
     specs_to_check = list(env.concretized_specs())
-    install_status = [len(specs_to_check)] + [is_installed(x) for _, x in specs_to_check]
+    install_status = [len(specs_to_check)] + [
+        is_installed(x) for _, x in specs_to_check
+    ]
     has_installed_specs = all(install_status)
     if not args.source_only and not has_installed_specs:
-        tty.warn("Environment contains uninstalled specs, defaulting to source-only package")
+        tty.warn(
+            "Environment contains uninstalled specs, defaulting to source-only package"
+        )
         if args.binary_only:
             tty.die(
                 "Binary distribution requested, but the environment does not "

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -1,4 +1,5 @@
 import fnmatch
+import errno
 import glob
 import os
 import shutil
@@ -190,6 +191,13 @@ def call(module, cmd, argv):
     callme = getattr(module, cmd)
     callme(parser, args)
 
+def contains_only_nfs_file(path):
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            if not name.startswith(".nfs"):
+                return False
+    return True
+
 
 class DistributionPackager:
     def __init__(
@@ -261,7 +269,13 @@ class DistributionPackager:
             if "spack.yaml" in item:
                 continue
             elif os.path.isdir(fullname):
-                shutil.rmtree(fullname, ignore_errors=True)
+                try:
+                    shutil.rmtree(fullname)
+                except OSError as e:
+                    if e.errno == errno.ENOTEMPTY and contains_only_nfs_file(fullname):
+                        print(f"Skipping non-empty directory error for {fullname}")
+                        continue
+                    raise
             else:
                 os.remove(fullname)
 

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -261,7 +261,7 @@ class DistributionPackager:
             if "spack.yaml" in item:
                 continue
             elif os.path.isdir(fullname):
-                shutil.rmtree(fullname)
+                shutil.rmtree(fullname, ignore_errors=True)
             else:
                 os.remove(fullname)
 

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -18,9 +18,10 @@ import spack.extensions
 
 try:
     import spack.llnl.util.filesystem as fs
+    import spack.llnl.util.tty as tty
 except ImportError:
     import spack.util.filesystem as fs
-import spack.llnl.util.tty as tty
+    import spack.util.tty as tty
 import spack.main
 import spack.solver.asp
 import spack.spec

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -10,8 +10,10 @@ import os
 import spack
 import spack.config
 import spack.environment as ev
-import spack.llnl.util.tty as tty
-import spack.util.spack_yaml as syaml
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as ttyimport spack.util.spack_yaml as syaml
 from spack.detection.common import _pkg_config_dict
 from spack.extensions.manager.environment_utils import SpackManagerEnvironmentManifest
 from spack.extensions.manager.manager_utils import pruned_spec_string

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -13,7 +13,7 @@ import spack.environment as ev
 try:
     import spack.llnl.util.tty as tty
 except ImportError:
-    import spack.util.tty as ttyimport spack.util.spack_yaml as syaml
+    import spack.util.tty as tty
 from spack.detection.common import _pkg_config_dict
 from spack.extensions.manager.environment_utils import SpackManagerEnvironmentManifest
 from spack.extensions.manager.manager_utils import pruned_spec_string

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -10,6 +10,7 @@ import os
 import spack
 import spack.config
 import spack.environment as ev
+import spack.util.spack_yaml as syaml
 
 try:
     import spack.llnl.util.tty as tty

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -10,6 +10,7 @@ import os
 import spack
 import spack.config
 import spack.environment as ev
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:
@@ -116,12 +117,16 @@ def external(parser, args):
     snap_env.check_views()
 
     if not snap_env.views:
-        tty.die("Environments used to create externals must have at least 1 associated view")
+        tty.die(
+            "Environments used to create externals must have at least 1 associated view"
+        )
     # copy the file and overwrite any that may exist (or merge?)
     inc_name_abs = os.path.abspath(os.path.join(env.path, args.name))
 
     try:
-        detected = assemble_dict_of_detected_externals(snap_env, args.exclude, args.include)
+        detected = assemble_dict_of_detected_externals(
+            snap_env, args.exclude, args.include
+        )
         src = create_yaml_from_detected_externals(detected)
     except ev.SpackEnvironmentError as e:
         tty.die(e.long_message)
@@ -149,7 +154,9 @@ def external(parser, args):
 
 def add_command(parser, command_dict):
     ext = parser.add_parser(
-        "external", help="tools for configuring precompiled binaries", conflict_handler="resolve"
+        "external",
+        help="tools for configuring precompiled binaries",
+        conflict_handler="resolve",
     )
 
     ext.add_argument(
@@ -182,7 +189,9 @@ def add_command(parser, command_dict):
         required=False,
         help="(not implemented) specs that should be omitted (add all others)",
     )
-    ext.add_argument("path", nargs="?", help="The location of the external install directory")
+    ext.add_argument(
+        "path", nargs="?", help="The location of the external install directory"
+    )
     ext.set_defaults(merge=False, name="externals.yaml")
 
     command_dict["external"] = external

--- a/manager/manager_cmds/include.py
+++ b/manager/manager_cmds/include.py
@@ -8,7 +8,10 @@
 import os
 import sys
 
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 
 from .. import projects
 from .find_machine import find_machine, machine_defined

--- a/manager/manager_cmds/include.py
+++ b/manager/manager_cmds/include.py
@@ -71,9 +71,12 @@ def include_creator(parser, args):
 
 def add_command(parser, command_dict):
     sub_parser = parser.add_parser(
-        "include", help="create machine specific includes files for consistent environments"
+        "include",
+        help="create machine specific includes files for consistent environments",
     )
-    sub_parser.add_argument("-m", "--machine", required=False, help="Machine to match configs")
+    sub_parser.add_argument(
+        "-m", "--machine", required=False, help="Machine to match configs"
+    )
     sub_parser.add_argument(
         "-f", "--file", required=False, help="Name of the include file to create"
     )

--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -12,7 +12,10 @@ import string
 import sys
 
 import spack.environment as ev
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 from spack.spec import Spec
 
 command_name = "lock-diff"

--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -12,6 +12,7 @@ import string
 import sys
 
 import spack.environment as ev
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:
@@ -19,12 +20,16 @@ except ImportError:
 from spack.spec import Spec
 
 command_name = "lock-diff"
-description = "compare two lock files to determine differences in the concrete environments"
+description = (
+    "compare two lock files to determine differences in the concrete environments"
+)
 aliases = ["ld"]
 
 
 def setup_parser_args(subparser):
-    subparser.add_argument("--old", "-o", help="path to the older spack.lock", required=True)
+    subparser.add_argument(
+        "--old", "-o", help="path to the older spack.lock", required=True
+    )
     subparser.add_argument(
         "--new", "-n", help="path to the newer/updated spack.lock", required=True
     )
@@ -131,7 +136,9 @@ def lock_diff(parser, args):
                     )
                 if old_spec.variants != new_spec.variants:
                     # since package hash is the same, varints should be the same too
-                    old_vars, new_vars = old_vs_new(old_spec.variants, new_spec.variants)
+                    old_vars, new_vars = old_vs_new(
+                        old_spec.variants, new_spec.variants
+                    )
                     diff_msg += "\n *variants diff - \n\tOld: {}\n\tNew: {}".format(
                         old_vars, new_vars
                     )

--- a/manager/manager_cmds/make.py
+++ b/manager/manager_cmds/make.py
@@ -32,7 +32,10 @@ level = "short"
 
 def setup_parser(parser):
     parser.add_argument(
-        "spec", metavar="SPEC", nargs="+", help="Spack package to build (must be a develop spec)"
+        "spec",
+        metavar="SPEC",
+        nargs="+",
+        help="Spack package to build (must be a develop spec)",
     )
     build_args = parser.add_mutually_exclusive_group()
     build_args.add_argument(
@@ -69,7 +72,9 @@ def make(parser, args):
     pkg = spec.package
     builder = spack.builder.create(pkg)
     if hasattr(builder, "build_directory"):
-        build_directory = os.path.normpath(os.path.join(pkg.stage.path, builder.build_directory))
+        build_directory = os.path.normpath(
+            os.path.join(pkg.stage.path, builder.build_directory)
+        )
     else:
         build_directory = pkg.stage.source_path
     try:

--- a/manager/manager_cmds/make.py
+++ b/manager/manager_cmds/make.py
@@ -13,9 +13,9 @@ import spack.cmd
 import spack.paths
 
 try:
-    from spack.util.filesystem import working_dir
-except ImportError:
     from spack.llnl.util.filesystem import working_dir
+except ImportError:
+    from spack.util.filesystem import working_dir
 import spack.llnl.util.tty as tty
 from spack.util.executable import Executable
 

--- a/manager/manager_cmds/make.py
+++ b/manager/manager_cmds/make.py
@@ -14,9 +14,10 @@ import spack.paths
 
 try:
     from spack.llnl.util.filesystem import working_dir
+    import spack.llnl.util.tty as tty
 except ImportError:
     from spack.util.filesystem import working_dir
-import spack.llnl.util.tty as tty
+    import spack.util.tty as tty
 from spack.util.executable import Executable
 
 """

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -12,7 +12,10 @@ Functions for snapshot creation that are added here to be testable
 import os
 
 import spack.cmd
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.main
 import spack.traverse as traverse
 import spack.util.executable

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -12,6 +12,7 @@ Functions for snapshot creation that are added here to be testable
 import os
 
 import spack.cmd
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:
@@ -73,7 +74,14 @@ def find_latest_git_hash(spec):
         tty.debug(f"{spec.name} has paired to git branch {branch}")
         # get the matching entry and shas for github
         query = (
-            git("ls-remote", "-h", spec.package.git, branch, output=str, error=os.devnull)
+            git(
+                "ls-remote",
+                "-h",
+                spec.package.git,
+                branch,
+                output=str,
+                error=os.devnull,
+            )
             .strip()
             .split()
         )
@@ -150,7 +158,9 @@ def pin_env(parser, args):
     pinDeps = args.dependencies or args.all
 
     if not env.concrete_roots():
-        tty.die("No concrete root specs detected. Pin requires a pre-concretized environment")
+        tty.die(
+            "No concrete root specs detected. Pin requires a pre-concretized environment"
+        )
 
     for user, root in env.concretized_specs():
         new_root = pin_graph(root, pinRoot, pinDeps)
@@ -163,7 +173,11 @@ def pin_env(parser, args):
 def setup_parser_args(sub_parser):
     spec_types = sub_parser.add_mutually_exclusive_group()
     spec_types.add_argument(
-        "-r", "--roots", action="store_true", default=False, help="only pin root spec versions"
+        "-r",
+        "--roots",
+        action="store_true",
+        default=False,
+        help="only pin root spec versions",
     )
     spec_types.add_argument(
         "-d",
@@ -173,7 +187,11 @@ def setup_parser_args(sub_parser):
         help="only pin root spec dependencie versions",
     )
     spec_types.add_argument(
-        "-a", "--all", action="store_true", default=True, help="pin all specs in the DAG"
+        "-a",
+        "--all",
+        action="store_true",
+        default=True,
+        help="pin all specs in the DAG",
     )
 
 

--- a/manager/manager_cmds/snapshot.py
+++ b/manager/manager_cmds/snapshot.py
@@ -35,7 +35,9 @@ class create_args:
     @property
     def yaml(self):
         # TODO the module root isn't getting renamed based off args.name like it should
-        return os.path.join(os.environ["SPACK_MANAGER"], "env-templates", "snapshot.yaml")
+        return os.path.join(
+            os.environ["SPACK_MANAGER"], "env-templates", "snapshot.yaml"
+        )
 
     @property
     def spec(self):
@@ -140,7 +142,10 @@ def add_command(parser, command_dict):
         help="don't replace branch version with latest git hashes as verions",
     )
     sub_parser.add_argument(
-        "--name", "-n", required=False, help="name the environment something other than the date"
+        "--name",
+        "-n",
+        required=False,
+        help="name the environment something other than the date",
     )
     sub_parser.add_argument(
         "--use_machine_name",
@@ -149,7 +154,12 @@ def add_command(parser, command_dict):
         help="use machine name in the snapshot path instead of computed architecture",
     )
     sub_parser.add_argument(
-        "-s", "--specs", required=True, default=[], nargs="+", help="Specs to create snapshots for"
+        "-s",
+        "--specs",
+        required=True,
+        default=[],
+        nargs="+",
+        help="Specs to create snapshots for",
     )
     sub_parser.add_argument(
         "-i",

--- a/manager/manager_utils.py
+++ b/manager/manager_utils.py
@@ -37,11 +37,15 @@ def canonicalize_path(path, default_wd=None):
     return spack_path_resolve(path, default_wd=default_wd)
 
 
-def pruned_spec_string(spec, variants_to_omit=["ipo", "dev_path=", "patches=", "build_system="]):
+def pruned_spec_string(
+    spec, variants_to_omit=["ipo", "dev_path=", "patches=", "build_system="]
+):
     full_spec = spec.format("{name}{@version}{variants}{%compiler}")
 
     # add spaces between variants so we can filter
-    spec_components = full_spec.replace("+", " +").replace("%", " %").replace("~", " ~").split(" ")
+    spec_components = (
+        full_spec.replace("+", " +").replace("%", " %").replace("~", " ~").split(" ")
+    )
 
     def filter_func(entry):
         for v in variants_to_omit:

--- a/manager/projects.py
+++ b/manager/projects.py
@@ -7,9 +7,9 @@
 import os
 
 try:
-    import spack.util.lang as lang
-except ImportError:
     import spack.llnl.util.lang as lang
+except ImportError:
+    import spack.util.lang as lang
 from . import config_yaml
 from .manager_utils import canonicalize_path
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -580,6 +580,7 @@ def test_concretize(tmpdir):
     pkgr.concretize()
     lockfile = os.path.join(env_dir, "spack.lock")
     assert os.path.isfile(lockfile)
+    assert spack.config.get("concretizer:concretization_cache:enable") is False
 
 
 def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -6,6 +6,8 @@
 # for more details.
 
 import os
+import errno
+import shutil
 from argparse import ArgumentParser
 
 import manager.manager_cmds.distribution as distribution
@@ -583,6 +585,29 @@ def test_concretize(tmpdir):
     assert spack.config.get("concretizer:concretization_cache:enable") is False
 
 
+def test_DistributionPackager_contains_only_nfs_file(tmpdir):
+    root = os.path.join(tmpdir.strpath, "root")
+    pkgr = distribution.DistributionPackager(None, root)
+
+    nfs_only_dir = os.path.join(tmpdir.strpath, "nfs_only")
+    os.makedirs(nfs_only_dir)
+    with open(os.path.join(nfs_only_dir, ".nfs000000000001"), "w") as out:
+        out.write("temp")
+    with open(os.path.join(nfs_only_dir, ".nfs000000000002"), "w") as out:
+        out.write("temp2")
+
+    assert distribution.contains_only_nfs_file(nfs_only_dir) is True
+
+    mixed_dir = os.path.join(tmpdir.strpath, "mixed")
+    os.makedirs(mixed_dir)
+    with open(os.path.join(mixed_dir, ".nfs000000000003"), "w") as out:
+        out.write("temp")
+    with open(os.path.join(mixed_dir, "real_file.txt"), "w") as out:
+        out.write("real")
+
+    assert distribution.contains_only_nfs_file(mixed_dir) is False
+
+
 def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     """
     This test verifies that `remove_unwanted_artifacts` removes files
@@ -614,6 +639,30 @@ def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     assert "spack.yaml" in env_assets
     assert not os.path.isfile(bad_file)
     assert os.path.isfile(good_file)
+
+
+def test_contains_only_nfs_file_true(tmpdir):
+    path = os.path.join(tmpdir.strpath, "nfs_only")
+    os.makedirs(path)
+
+    with open(os.path.join(path, ".nfs000000000001"), "w") as out:
+        out.write("busy")
+    with open(os.path.join(path, ".nfs000000000002"), "w") as out:
+        out.write("busy2")
+
+    assert distribution.contains_only_nfs_file(path) is True
+
+
+def test_contains_only_nfs_file_false(tmpdir):
+    path = os.path.join(tmpdir.strpath, "mixed")
+    os.makedirs(path)
+
+    with open(os.path.join(path, ".nfs000000000001"), "w") as out:
+        out.write("busy")
+    with open(os.path.join(path, "real_file.txt"), "w") as out:
+        out.write("real")
+
+    assert distribution.contains_only_nfs_file(path) is False
 
 
 def test_DistributionPackager_configure_includes(tmpdir):
@@ -1053,7 +1102,7 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_bootstrap_mirror()
 
-    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "buildcache"]
+    assert MockCommand.args == ["bootstrap", "bootstrap", "buildcache"]
 
     boostrap_parser = ArgumentParser()
     test_bootstrap_parse.setup_parser(boostrap_parser)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1102,7 +1102,7 @@ def test_DistributionPackager_configure_bootstrap_mirror(tmpdir, monkeypatch):
     monkeypatch.setattr(distribution, "call", MockCommand)
     pkgr.configure_bootstrap_mirror()
 
-    assert MockCommand.args == ["bootstrap", "bootstrap", "buildcache"]
+    assert MockCommand.args == ["bootstrap", "bootstrap", "bootstrap", "buildcache"]
 
     boostrap_parser = ArgumentParser()
     test_bootstrap_parse.setup_parser(boostrap_parser)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -6,8 +6,6 @@
 # for more details.
 
 import os
-import errno
-import shutil
 from argparse import ArgumentParser
 
 import manager.manager_cmds.distribution as distribution
@@ -177,7 +175,10 @@ def test_remove_by_pattern(tmpdir):
     ]
 
     bad_root = os.path.join(root, "bing")
-    bad = [os.path.join(bad_root, "bang", "bad.txt"), os.path.join(bad_root, "bing", "file.txt")]
+    bad = [
+        os.path.join(bad_root, "bang", "bad.txt"),
+        os.path.join(bad_root, "bing", "file.txt"),
+    ]
 
     for p in good + bad:
         os.makedirs(os.path.dirname(p), exist_ok=True)
@@ -200,7 +201,10 @@ def test_remove_by_pattern_with_overriding_includes(tmpdir):
     """
     root = os.path.join(tmpdir.strpath, "foo")
     bad_root = os.path.join(root, "bing")
-    bad = [os.path.join(bad_root, "bang", "bad.txt"), os.path.join(bad_root, "bing", "file.txt")]
+    bad = [
+        os.path.join(bad_root, "bang", "bad.txt"),
+        os.path.join(bad_root, "bing", "file.txt"),
+    ]
 
     good = [
         os.path.join(root, "bar", "file.txt"),
@@ -393,7 +397,9 @@ def test_correct_mirror_args_does_no_modification_if_install_verified(monkeypatc
     assert not args.binary_only
 
 
-def test_correct_mirror_args_does_errors_if_binary_only_but_no_binaries_exist(monkeypatch):
+def test_correct_mirror_args_does_errors_if_binary_only_but_no_binaries_exist(
+    monkeypatch,
+):
     """
     This test verifies that `correct_mirror_args` errors out if binary_only
     is True and source_only gets defaulted to True.
@@ -492,7 +498,9 @@ def test_DistributionPackager_filter_exclude_configs_with_excludes_file(tmpdir):
     assert "specs" in content["spack"]
 
 
-def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_file(tmpdir):
+def test_DistributionPackager_filter_exclude_configs_with_excludes_config_and_file(
+    tmpdir,
+):
     """
     This test verifies that `filter_exclude_configs` correctly modifies the environment
     when an exclude config section and file is passed.
@@ -586,9 +594,6 @@ def test_concretize(tmpdir):
 
 
 def test_DistributionPackager_contains_only_nfs_file(tmpdir):
-    root = os.path.join(tmpdir.strpath, "root")
-    pkgr = distribution.DistributionPackager(None, root)
-
     nfs_only_dir = os.path.join(tmpdir.strpath, "nfs_only")
     os.makedirs(nfs_only_dir)
     with open(os.path.join(nfs_only_dir, ".nfs000000000001"), "w") as out:
@@ -737,8 +742,12 @@ def test_DistributionPackager_copy_extensions_files(tmpdir, monkeypatch):
     assert os.path.isdir(expected_extension_path)
     assert os.path.isdir(os.path.join(expected_extension_path, "spack-extensiona"))
     assert os.path.isdir(os.path.join(expected_extension_path, "spack-extensionb"))
-    assert os.path.isfile(os.path.join(expected_extension_path, "spack-extensiona", "test.py"))
-    assert os.path.isfile(os.path.join(expected_extension_path, "spack-extensionb", "test.py"))
+    assert os.path.isfile(
+        os.path.join(expected_extension_path, "spack-extensiona", "test.py")
+    )
+    assert os.path.isfile(
+        os.path.join(expected_extension_path, "spack-extensionb", "test.py")
+    )
 
 
 def test_DistributionPackager_configure_repos(tmpdir):
@@ -776,7 +785,9 @@ def test_DistributionPackager_configure_repos(tmpdir):
 
     expected = spack.util.spack_yaml.syaml_dict()
     for key, val in data.items():
-        expected[key] = f"../{os.path.basename(pkgr.package_repos)}/{os.path.basename(val)}"
+        expected[key] = (
+            f"../{os.path.basename(pkgr.package_repos)}/{os.path.basename(val)}"
+        )
 
     assert expected == result_config["spack"]["repos"]
 
@@ -996,7 +1007,10 @@ def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
             f"../bootstrap-mirror/metadata/{mirror_type}",
         ],
     ]
-    expected_update_index = ["buildcache", ["update-index", "../bootstrap-mirror/bootstrap_cache"]]
+    expected_update_index = [
+        "buildcache",
+        ["update-index", "../bootstrap-mirror/bootstrap_cache"],
+    ]
 
     assert expected_bootstrap_add in mock_data
     assert expected_update_index in mock_data
@@ -1009,7 +1023,9 @@ def _assert_boostrap_copy_from_env(monkeypatch, tmpdir, mirror_type):
     )
 
 
-def test_DistributionPackager_create_bootstrap_with_existing_sources(tmpdir, monkeypatch):
+def test_DistributionPackager_create_bootstrap_with_existing_sources(
+    tmpdir, monkeypatch
+):
     """
     Test that _create_bootstrap identifies existing bootstrap sources in the config,
     copies the root directory of those sources, and returns the correct relative paths.
@@ -1017,7 +1033,9 @@ def test_DistributionPackager_create_bootstrap_with_existing_sources(tmpdir, mon
     _assert_boostrap_copy_from_env(monkeypatch, tmpdir, "sources")
 
 
-def test_DistributionPackager_create_bootstrap_with_existing_binaries(tmpdir, monkeypatch):
+def test_DistributionPackager_create_bootstrap_with_existing_binaries(
+    tmpdir, monkeypatch
+):
     """
     Test that _create_bootstrap identifies existing bootstrap binaries in the config,
     copies the root directory of those sources, and returns the correct relative paths.
@@ -1025,7 +1043,9 @@ def test_DistributionPackager_create_bootstrap_with_existing_binaries(tmpdir, mo
     _assert_boostrap_copy_from_env(monkeypatch, tmpdir, "binaries")
 
 
-def test_DistributionPackager_configure_bootstrap_mirror_calls_update_index(tmpdir, monkeypatch):
+def test_DistributionPackager_configure_bootstrap_mirror_calls_update_index(
+    tmpdir, monkeypatch
+):
     """
     Test that configure_bootstrap_mirror calls 'spack buildcache update-index'
     after adding the bootstrap sources.
@@ -1043,7 +1063,9 @@ def test_DistributionPackager_configure_bootstrap_mirror_calls_update_index(tmpd
     monkeypatch.setattr(distribution, "call", MockCommand)
 
     # Mock _create_bootstrap to return a simple list
-    monkeypatch.setattr(pkgr, "_create_bootstrap", lambda e: [("internal-source", "some/path")])
+    monkeypatch.setattr(
+        pkgr, "_create_bootstrap", lambda e: [("internal-source", "some/path")]
+    )
 
     pkgr.configure_bootstrap_mirror()
 
@@ -1139,7 +1161,10 @@ def test_DistributionPackager_configure_bootstrap_mirror_fallback_to_empty_env(
     # Verify we attempted bootstrap mirror creation and then successfully
     # configured bootstrap sources/binaries plus updated the index.
     assert MockCommand.args[0] == "bootstrap"
-    assert ["update-index", "../bootstrap-mirror/bootstrap_cache"] in MockCommand.call_args
+    assert [
+        "update-index",
+        "../bootstrap-mirror/bootstrap_cache",
+    ] in MockCommand.call_args
     assert "buildcache" in MockCommand.args
 
     bootstrap_add_calls = [
@@ -1243,9 +1268,9 @@ def test_DistributionPackager_init_config(tmpdir, monkeypatch):
     with pkgr.env:
         for section in flattened_config:
             if section == "config":
-                flattened_config[section]["extensions"] != spack.config.CONFIG.get(section)[
-                    "extensions"
-                ]
+                flattened_config[section]["extensions"] != spack.config.CONFIG.get(
+                    section
+                )["extensions"]
             elif section == "concretizer":
                 assert flattened_config[section] != spack.config.CONFIG.get(section)
             else:


### PR DESCRIPTION
We are running into problems using NFS during the `spack mirror distribution --source-only` command. This issue happens after we create the source mirror for the new environment when we try to remove the directories in the new environment:

Example: 
```
$ spack manager distribution --source-only --distro-dir $COMMON_SOURCE_PACKAGE_DIR --extra-data extra_data --exclude-specs cth,acis --exclude-configs "config:build_stage,config:install_tree:root"
==> Concretizing env: /rnfs01/sierra/builds/sVRHJykUM/001/1540-compsim/sierra/automation/install-env....
==> Precleaning....
==> Excluding configurations: ['config:build_stage', 'config:install_tree:root']....
==> Executing: spack config remove config:build_stage
==> Executing: spack config remove config:install_tree:root
==> Adding specs to env: /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment....
...
...
Executing: spack mirror create --directory /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/source-mirror --exclude-specs cth acis sierra base adagio acme ...
...
...
==> Adding package zuzax@master.latest to mirror
==> Adding package zuzax-apps@master.latest to mirror
==> Error: [Errno 39] Directory not empty: '/rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment/.spack-env'
==> Archive stats:
    117  already present
    77   added
    0    failed to fetch.
==> Adding mirror to env: /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment....
==> Executing: spack mirror add internal-source ../source-mirror
==> Packing up Spack installation to /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack....
==> Packaging up extra data to /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package....
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/var/spack
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.git-blame-ignore-revs
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.git
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.gitattributes
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.gitignore
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/README.md
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/packages.yaml
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/site
Slurm job ci-38416033_1783296880 state: FAILED
```