### PR TITLE
Arrange llnl imports to be used as the first attempt and the new imports as the fallback

### DIFF
--- a/install.py
+++ b/install.py
@@ -16,7 +16,10 @@ import importlib.util
 import os
 import sys
 
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.main
 
 spec = importlib.util.spec_from_file_location(

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -17,9 +17,9 @@ import spack.llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
 
 try:
-    import spack.util.filesystem as fs
-except ImportError:
     import spack.llnl.util.filesystem as fs
+except ImportError:
+    import spack.util.filesystem as fs
 
 
 _default_config = """

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -13,7 +13,10 @@ other modules.
 
 import os
 
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.util.spack_yaml as syaml
 
 try:

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -9,6 +9,7 @@ import os
 import shutil
 
 import spack.cmd
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:

--- a/manager/manager_cmds/develop.py
+++ b/manager/manager_cmds/develop.py
@@ -9,7 +9,10 @@ import os
 import shutil
 
 import spack.cmd
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.util.executable
 from spack.cmd.develop import develop as s_develop
 from spack.cmd.develop import setup_parser as s_setup_parser

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -16,10 +16,13 @@ import spack.environment
 import spack.extensions
 
 try:
-    import spack.util.filesystem as fs
-except ImportError:
     import spack.llnl.util.filesystem as fs
-import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.filesystem as fs
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.main
 import spack.solver.asp
 import spack.spec

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -10,6 +10,7 @@ import os
 import spack
 import spack.config
 import spack.environment as ev
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -10,7 +10,10 @@ import os
 import spack
 import spack.config
 import spack.environment as ev
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.util.spack_yaml as syaml
 from spack.detection.common import _pkg_config_dict
 from spack.extensions.manager.environment_utils import SpackManagerEnvironmentManifest

--- a/manager/manager_cmds/include.py
+++ b/manager/manager_cmds/include.py
@@ -8,7 +8,10 @@
 import os
 import sys
 
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 
 from .. import projects
 from .find_machine import find_machine, machine_defined

--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -12,7 +12,10 @@ import string
 import sys
 
 import spack.environment as ev
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 from spack.spec import Spec
 
 command_name = "lock-diff"

--- a/manager/manager_cmds/lock_diff.py
+++ b/manager/manager_cmds/lock_diff.py
@@ -12,6 +12,7 @@ import string
 import sys
 
 import spack.environment as ev
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:

--- a/manager/manager_cmds/make.py
+++ b/manager/manager_cmds/make.py
@@ -13,10 +13,13 @@ import spack.cmd
 import spack.paths
 
 try:
-    from spack.util.filesystem import working_dir
-except ImportError:
     from spack.llnl.util.filesystem import working_dir
-import spack.llnl.util.tty as tty
+except ImportError:
+    from spack.util.filesystem import working_dir
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 from spack.util.executable import Executable
 
 """

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -12,6 +12,7 @@ Functions for snapshot creation that are added here to be testable
 import os
 
 import spack.cmd
+
 try:
     import spack.llnl.util.tty as tty
 except ImportError:

--- a/manager/manager_cmds/pin.py
+++ b/manager/manager_cmds/pin.py
@@ -12,7 +12,10 @@ Functions for snapshot creation that are added here to be testable
 import os
 
 import spack.cmd
-import spack.llnl.util.tty as tty
+try:
+    import spack.llnl.util.tty as tty
+except ImportError:
+    import spack.util.tty as tty
 import spack.main
 import spack.traverse as traverse
 import spack.util.executable

--- a/manager/projects.py
+++ b/manager/projects.py
@@ -7,9 +7,9 @@
 import os
 
 try:
-    import spack.util.lang as lang
-except ImportError:
     import spack.llnl.util.lang as lang
+except ImportError:
+    import spack.util.lang as lang
 from . import config_yaml
 from .manager_utils import canonicalize_path
 


### PR DESCRIPTION
Spack 1.1.1 has relocated some utilities that used to live in spack.llnl.*
We still use spack-manager with older versions of spack so try the old locations first, the fallback to their new imports.

Related to: https://github.com/sandialabs/spack-manager/pull/655