### PR TITLE
Create exception handling to skip nfs created files causing errors in spack manager distribution create mirror

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -1,3 +1,4 @@
+import errno
 import fnmatch
 import glob
 import os
@@ -194,6 +195,14 @@ def call(module, cmd, argv):
     callme(parser, args)
 
 
+def contains_only_nfs_file(path):
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            if not name.startswith(".nfs"):
+                return False
+    return True
+
+
 class DistributionPackager:
     def __init__(
         self, env, root, includes=None, exclude_configs=None, exclude_file=None, extra_data=None
@@ -264,7 +273,13 @@ class DistributionPackager:
             if "spack.yaml" in item:
                 continue
             elif os.path.isdir(fullname):
-                shutil.rmtree(fullname)
+                try:
+                    shutil.rmtree(fullname)
+                except OSError as e:
+                    if e.errno == errno.ENOTEMPTY and contains_only_nfs_file(fullname):
+                        print(f"Skipping non-empty directory error for {fullname}")
+                        continue
+                    raise
             else:
                 os.remove(fullname)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -583,6 +583,26 @@ def test_concretize(tmpdir):
     assert spack.config.get("concretizer:concretization_cache:enable") is False
 
 
+def test_DistributionPackager_contains_only_nfs_file(tmpdir):
+    nfs_only_dir = os.path.join(tmpdir.strpath, "nfs_only")
+    os.makedirs(nfs_only_dir)
+    with open(os.path.join(nfs_only_dir, ".nfs000000000001"), "w") as out:
+        out.write("temp")
+    with open(os.path.join(nfs_only_dir, ".nfs000000000002"), "w") as out:
+        out.write("temp2")
+
+    assert distribution.contains_only_nfs_file(nfs_only_dir) is True
+
+    mixed_dir = os.path.join(tmpdir.strpath, "mixed")
+    os.makedirs(mixed_dir)
+    with open(os.path.join(mixed_dir, ".nfs000000000003"), "w") as out:
+        out.write("temp")
+    with open(os.path.join(mixed_dir, "real_file.txt"), "w") as out:
+        out.write("real")
+
+    assert distribution.contains_only_nfs_file(mixed_dir) is False
+
+
 def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     """
     This test verifies that `remove_unwanted_artifacts` removes files
@@ -614,6 +634,30 @@ def test_DistributionPackager_remove_unwanted_artifacts(tmpdir, monkeypatch):
     assert "spack.yaml" in env_assets
     assert not os.path.isfile(bad_file)
     assert os.path.isfile(good_file)
+
+
+def test_contains_only_nfs_file_true(tmpdir):
+    path = os.path.join(tmpdir.strpath, "nfs_only")
+    os.makedirs(path)
+
+    with open(os.path.join(path, ".nfs000000000001"), "w") as out:
+        out.write("busy")
+    with open(os.path.join(path, ".nfs000000000002"), "w") as out:
+        out.write("busy2")
+
+    assert distribution.contains_only_nfs_file(path) is True
+
+
+def test_contains_only_nfs_file_false(tmpdir):
+    path = os.path.join(tmpdir.strpath, "mixed")
+    os.makedirs(path)
+
+    with open(os.path.join(path, ".nfs000000000001"), "w") as out:
+        out.write("busy")
+    with open(os.path.join(path, "real_file.txt"), "w") as out:
+        out.write("real")
+
+    assert distribution.contains_only_nfs_file(path) is False
 
 
 def test_DistributionPackager_configure_includes(tmpdir):


### PR DESCRIPTION
We are running into problems using NFS during the spack mirror distribution --source-only command. This issue happens after we create the source mirror for the new environment when we try to remove the directories in the new environment:

Example:
```
$ spack manager distribution --source-only --distro-dir $COMMON_SOURCE_PACKAGE_DIR --extra-data extra_data --exclude-specs cth,acis --exclude-configs "config:build_stage,config:install_tree:root"
==> Concretizing env: /rnfs01/sierra/builds/sVRHJykUM/001/1540-compsim/sierra/automation/install-env....
==> Precleaning....
==> Excluding configurations: ['config:build_stage', 'config:install_tree:root']....
==> Executing: spack config remove config:build_stage
==> Executing: spack config remove config:install_tree:root
==> Adding specs to env: /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment....
...
...
Executing: spack mirror create --directory /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/source-mirror --exclude-specs cth acis sierra base adagio acme ...
...
...
==> Adding package zuzax@master.latest to mirror
==> Adding package zuzax-apps@master.latest to mirror
==> Error: [Errno 39] Directory not empty: '/rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment/.spack-env'
==> Archive stats:
    117  already present
    77   added
    0    failed to fetch.
==> Adding mirror to env: /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/environment....
==> Executing: spack mirror add internal-source ../source-mirror
==> Packing up Spack installation to /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack....
==> Packaging up extra data to /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package....
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/var/spack
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.git-blame-ignore-revs
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.git
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.gitattributes
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/.gitignore
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/README.md
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/packages.yaml
==> /rnfs01/sierra/.ci_pipelines/5496552/cts1+_source_package/spack/etc/spack/site
Slurm job ci-38416033_1783296880 state: FAILED
```

We need a way to gracefully handle the error above in distribution.py.