### PR TITLE
Ensure environment is active before concretizing

### DIFF
--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -256,10 +256,13 @@ class DistributionPackager:
         os.makedirs(self.path)
 
     def concretize(self):
-        spack.config.add("concretizer:concretization_cache:enable:false")
         tty.msg(f"Concretizing env: {self.env.name}....")
-        self.env.concretize(force=True)
-        self.env.write()
+        with self.env:
+            spack.config.add(
+                "concretizer:concretization_cache:enable:false", scope=self.env.scope_name
+            )
+            self.env.concretize(force=True)
+            self.env.write()
 
     def remove_unwanted_artifacts(self):
         include_patterns = [

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -262,7 +262,7 @@ class DistributionPackager:
     def concretize(self):
         tty.msg(f"Concretizing env: {self.env.name}....")
         with self.env:
-            spack.config.add(
+            spack.config.CONFIG.add(
                 "concretizer:concretization_cache:enable:false", scope=self.env.scope_name
             )
             self.env.concretize(force=True)
@@ -379,7 +379,7 @@ class DistributionPackager:
         with self.environment_to_package:
             repos = spack.util.spack_yaml.syaml_dict()
             for scope in valid_env_scopes(self.environment_to_package):
-                repos.update(spack.config.get("repos", scope=scope))
+                repos.update(spack.config.CONFIG.get("repos", scope=scope))
 
         tty.msg(f"Packing up package repositories to {self.package_repos}....")
         os.makedirs(self.package_repos)

--- a/manager/manager_cmds/distribution.py
+++ b/manager/manager_cmds/distribution.py
@@ -17,6 +17,10 @@ import spack.environment
 import spack.extensions
 
 try:
+    from spack.active_environment import active_environment as active_environment
+except ImportError:
+    active_environment = spack.environment.active_environment
+try:
     import spack.llnl.util.filesystem as fs
 except ImportError:
     import spack.util.filesystem as fs
@@ -228,7 +232,7 @@ class DistributionPackager:
         self._cached_env = None
 
     def __enter__(self):
-        self._cached_env = spack.environment.active_environment()
+        self._cached_env = active_environment()
         tty.msg(f"Concretizing env: {self.environment_to_package.name}....")
         self.environment_to_package.concretize()
         self.environment_to_package.write()

--- a/manager/manager_cmds/external.py
+++ b/manager/manager_cmds/external.py
@@ -12,6 +12,10 @@ import spack.config
 import spack.environment as ev
 
 try:
+    from spack.active_environment import active_environment as active_environment
+except ImportError:
+    active_environment = ev.active_environment
+try:
     import spack.llnl.util.tty as tty
 except ImportError:
     import spack.util.tty as tty
@@ -57,7 +61,7 @@ def create_external_detected_spec(env, spec):
 
 def assemble_dict_of_detected_externals(env, exclude, include):
     external_spec_dict = {}
-    active_env = ev.active_environment()
+    active_env = active_environment()
 
     def update_dictionary(env, spec):
         ext_spec = create_external_detected_spec(env, spec)
@@ -102,7 +106,7 @@ def _get_first_view_containing_spec(env, spec):
 
 
 def external(parser, args):
-    env = ev.active_environment()
+    env = active_environment()
     if not env:
         tty.die("spack manager external requires an active environment")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ import pytest
 import spack.extensions
 from spack.test.conftest import *  # noqa: F401 F403
 
+pytest_plugins = ["spack.test.concretization_cache_plugin"]
+
 _test_root = os.path.dirname(__file__)
 
 spack.extensions.load_extension("manager")

--- a/tests/test_create_env.py
+++ b/tests/test_create_env.py
@@ -124,6 +124,6 @@ def test_local_source_tree_can_be_added_to_env(tmpdir):
         manager("create-env", "-s", "nalu-wind", "-l")
         e = env.Environment(tmpdir.strpath)
         with e:
-            install_tree = spack.config.get("config:install_tree")
+            install_tree = spack.config.CONFIG.get("config:install_tree")
 
         assert "$env/opt" in str(install_tree)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -585,7 +585,7 @@ def test_concretize(tmpdir):
     pkgr.concretize()
     lockfile = os.path.join(env_dir, "spack.lock")
     assert os.path.isfile(lockfile)
-    assert spack.config.get("concretizer:concretization_cache:enable") is False
+    assert spack.config.CONFIG.get("concretizer:concretization_cache:enable") is False
 
 
 def test_DistributionPackager_contains_only_nfs_file(tmpdir):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -22,6 +22,11 @@ import spack.solver.asp
 import spack.spec
 import spack.util.spack_yaml
 
+try:
+    from spack.active_environment import active_environment as active_environment
+except ImportError:
+    active_environment = spack.environment.active_environment
+
 
 def create_spack_manifest(path, specs=None, extra_data=None):
     os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -862,11 +867,11 @@ def test_DistributionPackager_context_erases_working_dir(tmpdir):
     with open(testfile, "w") as f:
         f.write("content")
     with env:
-        assert spack.environment.active_environment().name == env.name
+        assert active_environment().name == env.name
         with pkgr:
-            assert spack.environment.active_environment() is None
+            assert active_environment() is None
             assert not os.path.exists(testfile)
-        assert spack.environment.active_environment().name == env.name
+        assert active_environment().name == env.name
 
 
 def test_DistributionPackager_context_creates_working_dir(tmpdir):
@@ -876,11 +881,11 @@ def test_DistributionPackager_context_creates_working_dir(tmpdir):
     pkgr, root, env = init_test_environment(tmpdir.strpath)
 
     with env:
-        assert spack.environment.active_environment().name == env.name
+        assert active_environment().name == env.name
         with pkgr:
-            assert spack.environment.active_environment() is None
+            assert active_environment() is None
             assert os.path.isdir(root)
-        assert spack.environment.active_environment().name == env.name
+        assert active_environment().name == env.name
 
 
 def test_DistributionPackager_configure_source_mirror(tmpdir, monkeypatch):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -585,7 +585,8 @@ def test_concretize(tmpdir):
     pkgr.concretize()
     lockfile = os.path.join(env_dir, "spack.lock")
     assert os.path.isfile(lockfile)
-    assert spack.config.CONFIG.get("concretizer:concretization_cache:enable") is False
+    with pkgr.env:
+        assert spack.config.CONFIG.get("concretizer:concretization_cache:enable") is False
 
 
 def test_DistributionPackager_contains_only_nfs_file(tmpdir):


### PR DESCRIPTION
Whether or not it needs to be is still somewhat unclear to me, but the behavior when not active was definitely missing pieces of the configuration.  Activating it via context manager prior to concretizing seems perfectly fine and fixes the issues I'm seeing.

Also added compatibility fixes for current Spack `develop` version.